### PR TITLE
Restructure DynamoDB

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -17,6 +17,6 @@ export DYNAMODB_USERS_TABLE_NAME="expenseus-dev-users"
 export DYNAMODB_TRANSACTIONS_TABLE_NAME="expenseus-dev-transactions"
 export DYNAMODB_DEV_ID=
 export DYNAMODB_DEV_SECRET=
-
+# for tests
 export DYNAMODB_TEST_ID=
 export DYNAMODB_TEST_SECRET=

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -10,7 +10,7 @@
 ### Above combination will ignore all files without extension ###
 
 # environment variables file
-.envrc
+.env
 
 # nextjs files
 web/dist

--- a/server/internal/app/app.go
+++ b/server/internal/app/app.go
@@ -16,7 +16,7 @@ const (
 )
 
 type Store interface {
-	GetTransaction(userID, txnID string) (Transaction, error)
+	GetTransaction(txnID string) (Transaction, error)
 	GetTransactionsByUser(userID string) ([]Transaction, error)
 	GetAllTransactions() ([]Transaction, error)
 	CreateTransaction(transactionDetails TransactionDetails) error

--- a/server/internal/app/app.go
+++ b/server/internal/app/app.go
@@ -16,8 +16,8 @@ const (
 )
 
 type Store interface {
-	GetTransaction(id string) (Transaction, error)
-	GetTransactionsByUsername(username string) ([]Transaction, error)
+	GetTransaction(userID, txnID string) (Transaction, error)
+	GetTransactionsByUser(userID string) ([]Transaction, error)
 	GetAllTransactions() ([]Transaction, error)
 	CreateTransaction(transactionDetails TransactionDetails) error
 	CreateUser(user User) error

--- a/server/internal/app/testing.go
+++ b/server/internal/app/testing.go
@@ -134,7 +134,7 @@ func NewCreateTransactionRequest(values map[string]io.Reader) *http.Request {
 // transactions of a user, with the user in the request context.
 func NewGetTransactionsByUserRequest(userID string) *http.Request {
 	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/transactions/user/%s", userID), nil)
-	ctx := context.WithValue(req.Context(), CtxKeyUsername, userID)
+	ctx := context.WithValue(req.Context(), CtxKeyUserID, userID)
 	return req.WithContext(ctx)
 }
 

--- a/server/internal/app/testing.go
+++ b/server/internal/app/testing.go
@@ -255,7 +255,7 @@ type StubTransactionStore struct {
 	recordTransactionCalls []TransactionDetails
 }
 
-func (s *StubTransactionStore) GetTransaction(userID, transactionID string) (Transaction, error) {
+func (s *StubTransactionStore) GetTransaction(transactionID string) (Transaction, error) {
 	transaction := s.transactions[transactionID]
 	// check for empty Transaction
 	if transaction == (Transaction{}) {

--- a/server/internal/app/testing.go
+++ b/server/internal/app/testing.go
@@ -130,11 +130,11 @@ func NewCreateTransactionRequest(values map[string]io.Reader) *http.Request {
 	return req
 }
 
-// NewGetTransactionsByUsernameRequest creates a request to be used in tests to get all
+// NewGetTransactionsByUserRequest creates a request to be used in tests to get all
 // transactions of a user, with the user in the request context.
-func NewGetTransactionsByUsernameRequest(username string) *http.Request {
-	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/transactions/user/%s", username), nil)
-	ctx := context.WithValue(req.Context(), CtxKeyUsername, username)
+func NewGetTransactionsByUserRequest(userID string) *http.Request {
+	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/transactions/user/%s", userID), nil)
+	ctx := context.WithValue(req.Context(), CtxKeyUsername, userID)
 	return req.WithContext(ctx)
 }
 
@@ -255,8 +255,8 @@ type StubTransactionStore struct {
 	recordTransactionCalls []TransactionDetails
 }
 
-func (s *StubTransactionStore) GetTransaction(id string) (Transaction, error) {
-	transaction := s.transactions[id]
+func (s *StubTransactionStore) GetTransaction(userID, transactionID string) (Transaction, error) {
+	transaction := s.transactions[transactionID]
 	// check for empty Transaction
 	if transaction == (Transaction{}) {
 		return Transaction{}, errors.New("transaction not found")
@@ -264,10 +264,10 @@ func (s *StubTransactionStore) GetTransaction(id string) (Transaction, error) {
 	return transaction, nil
 }
 
-func (s *StubTransactionStore) GetTransactionsByUsername(username string) ([]Transaction, error) {
+func (s *StubTransactionStore) GetTransactionsByUser(id string) ([]Transaction, error) {
 	var targetUser User
 	for _, u := range s.users {
-		if u.Username == username {
+		if u.ID == id {
 			targetUser = u
 			break
 		}

--- a/server/internal/app/transactions.go
+++ b/server/internal/app/transactions.go
@@ -53,9 +53,9 @@ func (a *App) GetTransaction(rw http.ResponseWriter, r *http.Request) {
 // GetTransactionsByUser handles a HTTP request to get all transactions of a user,
 // returning a list of transactions.
 func (a *App) GetTransactionsByUser(rw http.ResponseWriter, r *http.Request) {
-	username := r.Context().Value(CtxKeyUsername).(string)
+	userID := r.Context().Value(CtxKeyUserID).(string)
 
-	transactions, err := a.store.GetTransactionsByUser(username)
+	transactions, err := a.store.GetTransactionsByUser(userID)
 
 	// TODO: account for different errors
 	if err != nil {

--- a/server/internal/app/transactions.go
+++ b/server/internal/app/transactions.go
@@ -27,7 +27,7 @@ type Transaction struct {
 func (a *App) GetTransaction(rw http.ResponseWriter, r *http.Request) {
 	transactionID := r.Context().Value(CtxKeyTransactionID).(string)
 
-	transaction, err := a.store.GetTransaction(transactionID, transactionID)
+	transaction, err := a.store.GetTransaction(transactionID)
 
 	// TODO: should account for different kinds of errors
 	if err != nil {

--- a/server/internal/app/transactions.go
+++ b/server/internal/app/transactions.go
@@ -27,7 +27,7 @@ type Transaction struct {
 func (a *App) GetTransaction(rw http.ResponseWriter, r *http.Request) {
 	transactionID := r.Context().Value(CtxKeyTransactionID).(string)
 
-	transaction, err := a.store.GetTransaction(transactionID)
+	transaction, err := a.store.GetTransaction(transactionID, transactionID)
 
 	// TODO: should account for different kinds of errors
 	if err != nil {
@@ -50,12 +50,12 @@ func (a *App) GetTransaction(rw http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// GetTransactionsByUsername handles a HTTP request to get all transactions of a user,
+// GetTransactionsByUser handles a HTTP request to get all transactions of a user,
 // returning a list of transactions.
-func (a *App) GetTransactionsByUsername(rw http.ResponseWriter, r *http.Request) {
+func (a *App) GetTransactionsByUser(rw http.ResponseWriter, r *http.Request) {
 	username := r.Context().Value(CtxKeyUsername).(string)
 
-	transactions, err := a.store.GetTransactionsByUsername(username)
+	transactions, err := a.store.GetTransactionsByUser(username)
 
 	// TODO: account for different errors
 	if err != nil {

--- a/server/internal/app/transactions_test.go
+++ b/server/internal/app/transactions_test.go
@@ -123,10 +123,10 @@ func TestGetTransactionByUser(t *testing.T) {
 	app := New(&store, &StubOauthConfig{}, &StubSessionManager{}, "", &StubImageStore{})
 
 	t.Run("gets tomochi's transactions", func(t *testing.T) {
-		request := NewGetTransactionsByUsernameRequest(TestTomomiUser.Username)
+		request := NewGetTransactionsByUserRequest(TestTomomiUser.ID)
 		response := httptest.NewRecorder()
 
-		handler := http.HandlerFunc(app.GetTransactionsByUsername)
+		handler := http.HandlerFunc(app.GetTransactionsByUser)
 		handler.ServeHTTP(response, request)
 
 		var got []Transaction
@@ -142,10 +142,10 @@ func TestGetTransactionByUser(t *testing.T) {
 	})
 
 	t.Run("gets saifahn's transactions", func(t *testing.T) {
-		request := NewGetTransactionsByUsernameRequest(TestSeanUser.Username)
+		request := NewGetTransactionsByUserRequest(TestSeanUser.ID)
 		response := httptest.NewRecorder()
 
-		handler := http.HandlerFunc(app.GetTransactionsByUsername)
+		handler := http.HandlerFunc(app.GetTransactionsByUser)
 		handler.ServeHTTP(response, request)
 
 		var got []Transaction

--- a/server/internal/app/users.go
+++ b/server/internal/app/users.go
@@ -6,8 +6,7 @@ import (
 )
 
 const (
-	CtxKeyUsername contextKey = iota
-	CtxKeyUserID   contextKey = iota
+	CtxKeyUserID contextKey = iota
 )
 
 type User struct {

--- a/server/internal/ddb/ddb.go
+++ b/server/internal/ddb/ddb.go
@@ -113,7 +113,7 @@ func txnItemToTxn(ti TransactionItem) app.Transaction {
 	}
 }
 
-func (d *dynamoDB) GetTransaction(userID, transactionID string) (app.Transaction, error) {
+func (d *dynamoDB) GetTransaction(transactionID string) (app.Transaction, error) {
 	ti, err := d.transactions.Get(transactionID)
 	if err != nil {
 		return app.Transaction{}, err

--- a/server/internal/ddb/ddb.go
+++ b/server/internal/ddb/ddb.go
@@ -15,8 +15,9 @@ type dynamoDB struct {
 }
 
 func New(d dynamodbiface.DynamoDBAPI, tableName string) *dynamoDB {
-	users := NewUserRepository(table.New(d, tableName))
-	transactions := NewTxnRepository(table.New(d, tableName))
+	tbl := table.New(d, tableName)
+	users := NewUserRepository(tbl)
+	transactions := NewTxnRepository(tbl)
 
 	return &dynamoDB{users: users, transactions: transactions}
 }

--- a/server/internal/ddb/ddb.go
+++ b/server/internal/ddb/ddb.go
@@ -25,11 +25,11 @@ func New(d dynamodbiface.DynamoDBAPI, usersTableName, transactionsTableName stri
 }
 
 func userToUserItem(u app.User) UserItem {
-	userIDKey := fmt.Sprintf("%s#%s", UserKeyPrefix, u.ID)
+	userIDKey := fmt.Sprintf("%s#%s", userKeyPrefix, u.ID)
 	return UserItem{
 		PK:         userIDKey,
 		SK:         userIDKey,
-		EntityType: UserEntityType,
+		EntityType: userEntityType,
 		ID:         u.ID,
 		GSI1PK:     allUsersKey,
 		GSI1SK:     userIDKey,
@@ -76,13 +76,13 @@ func (d *dynamoDB) GetAllUsers() ([]app.User, error) {
 func (d *dynamoDB) CreateTransaction(td app.TransactionDetails) error {
 	// generate an ID
 	transactionID := uuid.New().String()
-	userIDKey := fmt.Sprintf("%s#%s", UserKeyPrefix, td.UserID)
-	transactionIDKey := fmt.Sprintf("%s#%s", TransactionKeyPrefix, transactionID)
+	userIDKey := fmt.Sprintf("%s#%s", userKeyPrefix, td.UserID)
+	transactionIDKey := fmt.Sprintf("%s#%s", txnKeyPrefix, transactionID)
 
 	item := &TransactionItem{
 		PK:         userIDKey,
 		SK:         transactionIDKey,
-		EntityType: transactionEntityType,
+		EntityType: txnEntityType,
 		ID:         transactionID,
 		UserID:     td.UserID,
 		GSI1PK:     allTxnKey,

--- a/server/internal/ddb/ddb.go
+++ b/server/internal/ddb/ddb.go
@@ -59,7 +59,17 @@ func (d *dynamoDB) GetUser(id string) (app.User, error) {
 	return userItemToUser(ui), nil
 }
 
-	return user, nil
+func (d *dynamoDB) GetAllUsers() ([]app.User, error) {
+	userItems, err := d.usersTable.GetAll()
+	if err != nil {
+		return nil, err
+	}
+
+	var users []app.User
+	for _, ui := range userItems {
+		users = append(users, userItemToUser(ui))
+	}
+	return users, nil
 }
 
 func (d *dynamoDB) GetTransaction(id string) (app.Transaction, error) {
@@ -128,17 +138,4 @@ func (d *dynamoDB) CreateTransaction(ed app.TransactionDetails) error {
 
 	fmt.Println("transaction successfully created")
 	return nil
-}
-
-func (d *dynamoDB) GetAllUsers() ([]app.User, error) {
-	userItems, err := d.usersTable.GetAll()
-	if err != nil {
-		return nil, err
-	}
-
-	var users []app.User
-	for _, u := range userItems {
-		users = append(users, u.User)
-	}
-	return users, nil
 }

--- a/server/internal/ddb/ddb.go
+++ b/server/internal/ddb/ddb.go
@@ -23,9 +23,9 @@ func New(d dynamodbiface.DynamoDBAPI, usersTableName, transactionsTableName stri
 	return &dynamoDB{usersTable: usersTable, transactionsTable: transactionsTable}
 }
 
-func (d *dynamoDB) CreateUser(u app.User) error {
+func userToUserItem(u app.User) UserItem {
 	userIDKey := fmt.Sprintf("%s#%s", UserKeyPrefix, u.ID)
-	item := &UserItem{
+	return UserItem{
 		PK:         userIDKey,
 		SK:         userIDKey,
 		EntityType: UserEntityType,
@@ -33,7 +33,10 @@ func (d *dynamoDB) CreateUser(u app.User) error {
 		GSI1PK:     allUsersKey,
 		GSI1SK:     userIDKey,
 	}
-	err := d.usersTable.PutIfNotExists(*item)
+}
+
+func (d *dynamoDB) CreateUser(u app.User) error {
+	err := d.usersTable.PutIfNotExists(userToUserItem(u))
 	if err != nil {
 		return err
 	}
@@ -41,12 +44,20 @@ func (d *dynamoDB) CreateUser(u app.User) error {
 	return nil
 }
 
+func userItemToUser(ui UserItem) app.User {
+	return app.User{
+		ID: ui.ID,
+	}
+}
+
 func (d *dynamoDB) GetUser(id string) (app.User, error) {
-	u, err := d.usersTable.Get(id)
+	ui, err := d.usersTable.Get(id)
 	if err != nil {
 		return app.User{}, err
 	}
-	user := u.User
+
+	return userItemToUser(ui), nil
+}
 
 	return user, nil
 }

--- a/server/internal/ddb/ddb.go
+++ b/server/internal/ddb/ddb.go
@@ -1,7 +1,6 @@
 package ddb
 
 import (
-	"fmt"
 	"log"
 
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
@@ -23,7 +22,7 @@ func New(d dynamodbiface.DynamoDBAPI, tableName string) *dynamoDB {
 }
 
 func userToUserItem(u app.User) UserItem {
-	userIDKey := fmt.Sprintf("%s#%s", userKeyPrefix, u.ID)
+	userIDKey := makeUserIDKey(u.ID)
 	return UserItem{
 		PK:         userIDKey,
 		SK:         userIDKey,
@@ -76,10 +75,10 @@ func (d *dynamoDB) GetAllUsers() ([]app.User, error) {
 }
 
 func (d *dynamoDB) CreateTransaction(td app.TransactionDetails) error {
-	// generate an ID
+	userIDKey := makeUserIDKey(td.UserID)
+	// generate an ID for the transaction
 	transactionID := uuid.New().String()
-	userIDKey := fmt.Sprintf("%s#%s", userKeyPrefix, td.UserID)
-	transactionIDKey := fmt.Sprintf("%s#%s", txnKeyPrefix, transactionID)
+	transactionIDKey := makeTxnIDKey(transactionID)
 
 	item := &TransactionItem{
 		PK:         userIDKey,

--- a/server/internal/ddb/ddb.go
+++ b/server/internal/ddb/ddb.go
@@ -29,6 +29,8 @@ func userToUserItem(u app.User) UserItem {
 		SK:         userIDKey,
 		EntityType: userEntityType,
 		ID:         u.ID,
+		Username:   u.Username,
+		Name:       u.Name,
 		GSI1PK:     allUsersKey,
 		GSI1SK:     userIDKey,
 	}
@@ -45,7 +47,9 @@ func (d *dynamoDB) CreateUser(u app.User) error {
 
 func userItemToUser(ui UserItem) app.User {
 	return app.User{
-		ID: ui.ID,
+		ID:       ui.ID,
+		Username: ui.Username,
+		Name:     ui.Name,
 	}
 }
 
@@ -83,6 +87,9 @@ func (d *dynamoDB) CreateTransaction(td app.TransactionDetails) error {
 		EntityType: txnEntityType,
 		ID:         transactionID,
 		UserID:     td.UserID,
+		Name:       td.Name,
+		Amount:     td.Amount,
+		Date:       td.Date,
 		GSI1PK:     allTxnKey,
 		GSI1SK:     transactionIDKey,
 	}
@@ -95,22 +102,25 @@ func (d *dynamoDB) CreateTransaction(td app.TransactionDetails) error {
 	return nil
 }
 
-func transactionItemToTransaction(ti TransactionItem) app.Transaction {
+func txnItemToTxn(ti TransactionItem) app.Transaction {
 	return app.Transaction{
 		ID: ti.ID,
 		TransactionDetails: app.TransactionDetails{
 			UserID: ti.UserID,
+			Name:   ti.Name,
+			Amount: ti.Amount,
+			Date:   ti.Date,
 		},
 	}
 }
 
 func (d *dynamoDB) GetTransaction(userID, transactionID string) (app.Transaction, error) {
-	ti, err := d.transactions.Get(userID, transactionID)
+	ti, err := d.transactions.Get(transactionID)
 	if err != nil {
 		return app.Transaction{}, err
 	}
 
-	return transactionItemToTransaction(*ti), nil
+	return txnItemToTxn(*ti), nil
 }
 
 func (d *dynamoDB) GetAllTransactions() ([]app.Transaction, error) {
@@ -121,7 +131,7 @@ func (d *dynamoDB) GetAllTransactions() ([]app.Transaction, error) {
 
 	var transactions []app.Transaction
 	for _, ti := range transactionItems {
-		transactions = append(transactions, transactionItemToTransaction(ti))
+		transactions = append(transactions, txnItemToTxn(ti))
 	}
 
 	return transactions, nil
@@ -135,7 +145,7 @@ func (d *dynamoDB) GetTransactionsByUser(userID string) ([]app.Transaction, erro
 
 	transactions := []app.Transaction{}
 	for _, ti := range items {
-		transactions = append(transactions, transactionItemToTransaction(ti))
+		transactions = append(transactions, txnItemToTxn(ti))
 	}
 	return transactions, nil
 }

--- a/server/internal/ddb/ddb.go
+++ b/server/internal/ddb/ddb.go
@@ -2,6 +2,7 @@ package ddb
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
 	"github.com/google/uuid"
@@ -92,7 +93,7 @@ func (d *dynamoDB) CreateTransaction(td app.TransactionDetails) error {
 		return err
 	}
 
-	fmt.Println("transaction successfully created")
+	log.Println("transaction successfully created")
 	return nil
 }
 

--- a/server/internal/ddb/ddb.go
+++ b/server/internal/ddb/ddb.go
@@ -131,6 +131,15 @@ func (d *dynamoDB) GetTransactionsByUsername(username string) ([]app.Transaction
 	return transactions, nil
 }
 
+func transactionItemToTransaction(ti TransactionItem) app.Transaction {
+	return app.Transaction{
+		ID: ti.ID,
+		TransactionDetails: app.TransactionDetails{
+			UserID: ti.UserID,
+		},
+	}
+}
+
 func (d *dynamoDB) GetAllTransactions() ([]app.Transaction, error) {
 	transactionItems, err := d.transactionsTable.GetAll()
 	if err != nil {
@@ -138,11 +147,8 @@ func (d *dynamoDB) GetAllTransactions() ([]app.Transaction, error) {
 	}
 
 	var transactions []app.Transaction
-	for _, t := range transactionItems {
-		transactions = append(transactions, app.Transaction{
-			ID:                 t.ID,
-			TransactionDetails: t.TransactionDetails,
-		})
+	for _, ti := range transactionItems {
+		transactions = append(transactions, transactionItemToTransaction(ti))
 	}
 
 	return transactions, nil

--- a/server/internal/ddb/ddb.go
+++ b/server/internal/ddb/ddb.go
@@ -24,8 +24,14 @@ func New(d dynamodbiface.DynamoDBAPI, usersTableName, transactionsTableName stri
 }
 
 func (d *dynamoDB) CreateUser(u app.User) error {
+	userIDKey := fmt.Sprintf("%s#%s", UserKeyPrefix, u.ID)
 	item := &UserItem{
-		User: u,
+		PK:         userIDKey,
+		SK:         userIDKey,
+		EntityType: UserEntityType,
+		ID:         u.ID,
+		GSI1PK:     allUsersKey,
+		GSI1SK:     userIDKey,
 	}
 	err := d.usersTable.PutIfNotExists(*item)
 	if err != nil {

--- a/server/internal/ddb/errors.go
+++ b/server/internal/ddb/errors.go
@@ -5,7 +5,10 @@ import (
 	"github.com/pkg/errors"
 )
 
-var ErrConflict = errors.New("dynamodb: conflict")
+var (
+	ErrConflict   = errors.New("dynamodb: conflict")
+	ErrUnexpected = errors.New("dynamodb: something unexpected occurred")
+)
 
 func conflictOrErr(err error) error {
 	dynamoErr, ok := errors.Cause(err).(awserr.Error)

--- a/server/internal/ddb/schema.go
+++ b/server/internal/ddb/schema.go
@@ -4,4 +4,5 @@ const (
 	tablePrimaryKey = "PK"
 	tableSortKey    = "SK"
 	gsi1PrimaryKey  = "GSI1PK"
+	gsi1SortKey     = "GSI1SK"
 )

--- a/server/internal/ddb/schema.go
+++ b/server/internal/ddb/schema.go
@@ -1,0 +1,7 @@
+package ddb
+
+const (
+	tablePrimaryKey = "PK"
+	tableSortKey    = "SK"
+	gsi1PrimaryKey  = "GSI1PK"
+)

--- a/server/internal/ddb/testing.go
+++ b/server/internal/ddb/testing.go
@@ -19,6 +19,42 @@ func NewDynamoDBLocalAPI() dynamodbiface.DynamoDBAPI {
 	return dynamodb.New(sess)
 }
 
+func CreateExpenseusTable(d dynamodbiface.DynamoDBAPI, name string) error {
+	_, err := d.CreateTable(&dynamodb.CreateTableInput{
+		AttributeDefinitions: []*dynamodb.AttributeDefinition{
+			{
+				AttributeName: aws.String("PK"),
+				AttributeType: aws.String("S"),
+			},
+			{
+				AttributeName: aws.String("SK"),
+				AttributeType: aws.String("S"),
+			},
+		},
+		KeySchema: []*dynamodb.KeySchemaElement{
+			{
+				AttributeName: aws.String("PK"),
+				KeyType:       aws.String("HASH"),
+			},
+			{
+				AttributeName: aws.String("SK"),
+				KeyType:       aws.String("RANGE"),
+			},
+		},
+		ProvisionedThroughput: &dynamodb.ProvisionedThroughput{
+			ReadCapacityUnits:  aws.Int64(1),
+			WriteCapacityUnits: aws.Int64(1),
+		},
+		TableName: aws.String(name),
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("successfully created the table", name)
+	return nil
+}
+
 func CreateTestTable(d dynamodbiface.DynamoDBAPI, name string) error {
 	input := &dynamodb.CreateTableInput{
 		AttributeDefinitions: []*dynamodb.AttributeDefinition{

--- a/server/internal/ddb/testing.go
+++ b/server/internal/ddb/testing.go
@@ -1,7 +1,7 @@
 package ddb
 
 import (
-	"fmt"
+	"log"
 	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
 )
 
+// NewDynamoDBLocalAPI creates a new session with DynamoDB for local testing.
 func NewDynamoDBLocalAPI() dynamodbiface.DynamoDBAPI {
 	sess := session.Must(
 		session.NewSession(aws.NewConfig().WithCredentials(credentials.NewStaticCredentials(os.Getenv("DYNAMODB_TEST_ID"), os.Getenv("DYNAMODB_TEST_SECRET"), ""))),
@@ -19,6 +20,7 @@ func NewDynamoDBLocalAPI() dynamodbiface.DynamoDBAPI {
 	return dynamodb.New(sess)
 }
 
+// CreateTestTable creates a table for testing.
 func CreateTestTable(d dynamodbiface.DynamoDBAPI, name string) error {
 	_, err := d.CreateTable(&dynamodb.CreateTableInput{
 		AttributeDefinitions: []*dynamodb.AttributeDefinition{
@@ -77,16 +79,17 @@ func CreateTestTable(d dynamodbiface.DynamoDBAPI, name string) error {
 		return err
 	}
 
-	fmt.Println("successfully created the table", name)
+	log.Println("successfully created the table", name)
 	return nil
 }
 
+// DeleteTable deletes a table. It should only be used in testing.
 func DeleteTable(d dynamodbiface.DynamoDBAPI, name string) error {
 	_, err := d.DeleteTable(&dynamodb.DeleteTableInput{TableName: aws.String(name)})
 	if err != nil {
 		return err
 	}
 
-	fmt.Println("successfully deleted the table", name)
+	log.Println("successfully deleted the table", name)
 	return nil
 }

--- a/server/internal/ddb/testing.go
+++ b/server/internal/ddb/testing.go
@@ -30,6 +30,14 @@ func CreateTestTable(d dynamodbiface.DynamoDBAPI, name string) error {
 				AttributeName: aws.String("SK"),
 				AttributeType: aws.String("S"),
 			},
+			{
+				AttributeName: aws.String("GSI1PK"),
+				AttributeType: aws.String("S"),
+			},
+			{
+				AttributeName: aws.String("GSI1SK"),
+				AttributeType: aws.String("S"),
+			},
 		},
 		KeySchema: []*dynamodb.KeySchemaElement{
 			{
@@ -41,6 +49,24 @@ func CreateTestTable(d dynamodbiface.DynamoDBAPI, name string) error {
 				KeyType:       aws.String("RANGE"),
 			},
 		},
+		GlobalSecondaryIndexes: []*dynamodb.GlobalSecondaryIndex{{
+			IndexName: aws.String("GSI1"),
+			KeySchema: []*dynamodb.KeySchemaElement{
+				{
+					AttributeName: aws.String("GSI1PK"),
+					KeyType:       aws.String("HASH"),
+				},
+				{
+					AttributeName: aws.String("GSI1SK"),
+					KeyType:       aws.String("RANGE"),
+				},
+			},
+			Projection: &dynamodb.Projection{ProjectionType: aws.String(dynamodb.ProjectionTypeAll)},
+			ProvisionedThroughput: &dynamodb.ProvisionedThroughput{
+				ReadCapacityUnits:  aws.Int64(1),
+				WriteCapacityUnits: aws.Int64(1),
+			},
+		}},
 		ProvisionedThroughput: &dynamodb.ProvisionedThroughput{
 			ReadCapacityUnits:  aws.Int64(1),
 			WriteCapacityUnits: aws.Int64(1),

--- a/server/internal/ddb/testing.go
+++ b/server/internal/ddb/testing.go
@@ -19,7 +19,7 @@ func NewDynamoDBLocalAPI() dynamodbiface.DynamoDBAPI {
 	return dynamodb.New(sess)
 }
 
-func CreateExpenseusTable(d dynamodbiface.DynamoDBAPI, name string) error {
+func CreateTestTable(d dynamodbiface.DynamoDBAPI, name string) error {
 	_, err := d.CreateTable(&dynamodb.CreateTableInput{
 		AttributeDefinitions: []*dynamodb.AttributeDefinition{
 			{
@@ -47,35 +47,6 @@ func CreateExpenseusTable(d dynamodbiface.DynamoDBAPI, name string) error {
 		},
 		TableName: aws.String(name),
 	})
-	if err != nil {
-		return err
-	}
-
-	fmt.Println("successfully created the table", name)
-	return nil
-}
-
-func CreateTestTable(d dynamodbiface.DynamoDBAPI, name string) error {
-	input := &dynamodb.CreateTableInput{
-		AttributeDefinitions: []*dynamodb.AttributeDefinition{
-			{
-				AttributeName: aws.String("id"),
-				AttributeType: aws.String("S"),
-			},
-		},
-		KeySchema: []*dynamodb.KeySchemaElement{
-			{
-				AttributeName: aws.String("id"),
-				KeyType:       aws.String("HASH"),
-			},
-		},
-		ProvisionedThroughput: &dynamodb.ProvisionedThroughput{
-			ReadCapacityUnits:  aws.Int64(1),
-			WriteCapacityUnits: aws.Int64(1),
-		},
-		TableName: aws.String(name),
-	}
-	_, err := d.CreateTable(input)
 	if err != nil {
 		return err
 	}

--- a/server/internal/ddb/transactions.go
+++ b/server/internal/ddb/transactions.go
@@ -1,43 +1,48 @@
 package ddb
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/service/dynamodb"
-	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
-	"github.com/aws/aws-sdk-go/service/dynamodb/expression"
 	"github.com/nabeken/aws-go-dynamodb/attributes"
 	"github.com/nabeken/aws-go-dynamodb/table"
 	"github.com/nabeken/aws-go-dynamodb/table/option"
-	"github.com/saifahn/expenseus/internal/app"
 )
 
 type TransactionItem struct {
-	app.TransactionDetails
-	ID string `json:"id"`
+	PK         string `json:"PK"`
+	SK         string `json:"SK"`
+	ID         string `json:"ID"`
+	UserID     string `json:"UserID"`
+	EntityType string `json:"EntityType"`
 }
 
+const TransactionKeyPrefix = "txn"
+
 type TransactionsTable interface {
-	Get(id string) (*TransactionItem, error)
-	GetAll() ([]TransactionItem, error)
-	GetByUserID(userid string) ([]TransactionItem, error)
+	Get(userID, transactionID string) (*TransactionItem, error)
+	// GetAll() ([]TransactionItem, error)
+	// GetByUserID(userID string) ([]TransactionItem, error)
 	PutIfNotExists(item TransactionItem) error
 	Put(item TransactionItem) error
-	Delete(id string) error
+	Delete(userID, transactionID string) error
 }
 
 type transactionsTable struct {
 	table *table.Table
 }
 
-const TransactionsHashKeyName = "id"
-
 func NewTransactionsTable(t *table.Table) TransactionsTable {
-	t.WithHashKey(TransactionsHashKeyName, dynamodb.ScalarAttributeTypeS)
+	t.WithHashKey(HashKey, dynamodb.ScalarAttributeTypeS)
+	t.WithRangeKey(RangeKey, dynamodb.ScalarAttributeTypeS)
 	return &transactionsTable{table: t}
 }
 
-func (t *transactionsTable) Get(id string) (*TransactionItem, error) {
+func (t *transactionsTable) Get(userID, txnID string) (*TransactionItem, error) {
+	userKey := fmt.Sprintf("%s#%s", UserKeyPrefix, userID)
+	txnKey := fmt.Sprintf("%s#%s", TransactionKeyPrefix, txnID)
 	item := &TransactionItem{}
-	err := t.table.GetItem(attributes.String(id), nil, item, option.ConsistentRead())
+	err := t.table.GetItem(attributes.String(userKey), attributes.String(txnKey), item, option.ConsistentRead())
 	if err != nil {
 		return nil, err
 	}
@@ -47,7 +52,7 @@ func (t *transactionsTable) Get(id string) (*TransactionItem, error) {
 func (t *transactionsTable) PutIfNotExists(item TransactionItem) error {
 	err := t.table.PutItem(
 		item,
-		option.PutCondition("attribute_not_exists(id)"),
+		option.PutCondition("attribute_not_exists(SK)"),
 	)
 	if err != nil {
 		return conflictOrErr(err)
@@ -60,59 +65,61 @@ func (t *transactionsTable) Put(item TransactionItem) error {
 	return t.table.PutItem(item)
 }
 
-func (t *transactionsTable) Delete(id string) error {
-	return t.table.DeleteItem(attributes.String(id), nil)
+func (t *transactionsTable) Delete(userID, txnID string) error {
+	userKey := fmt.Sprintf("%s#%s", UserKeyPrefix, userID)
+	txnKey := fmt.Sprintf("%s#%s", TransactionKeyPrefix, txnID)
+	return t.table.DeleteItem(attributes.String(userKey), attributes.String(txnKey))
 }
 
-func (t *transactionsTable) GetAll() ([]TransactionItem, error) {
-	response, err := t.table.DynamoDB.Scan(&dynamodb.ScanInput{TableName: t.table.Name})
-	if err != nil {
-		return nil, err
-	}
-	var items []TransactionItem
+// func (t *transactionsTable) GetAll() ([]TransactionItem, error) {
+// 	response, err := t.table.DynamoDB.Scan(&dynamodb.ScanInput{TableName: t.table.Name})
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	var items []TransactionItem
 
-	for _, i := range response.Items {
-		var item TransactionItem
-		err = dynamodbattribute.UnmarshalMap(i, &item)
-		if err != nil {
-			return nil, err
-		}
-		items = append(items, item)
-	}
+// 	for _, i := range response.Items {
+// 		var item TransactionItem
+// 		err = dynamodbattribute.UnmarshalMap(i, &item)
+// 		if err != nil {
+// 			return nil, err
+// 		}
+// 		items = append(items, item)
+// 	}
 
-	return items, nil
-}
+// 	return items, nil
+// }
 
-func (t *transactionsTable) GetByUserID(userid string) ([]TransactionItem, error) {
-	filt := expression.Name("userId").Equal(expression.Value(userid))
-	expr, err := expression.NewBuilder().WithFilter(filt).Build()
-	if err != nil {
-		return nil, err
-	}
+// func (t *transactionsTable) GetByUserID(userid string) ([]TransactionItem, error) {
+// 	filt := expression.Name("userId").Equal(expression.Value(userid))
+// 	expr, err := expression.NewBuilder().WithFilter(filt).Build()
+// 	if err != nil {
+// 		return nil, err
+// 	}
 
-	params := &dynamodb.ScanInput{
-		ExpressionAttributeNames:  expr.Names(),
-		ExpressionAttributeValues: expr.Values(),
-		FilterExpression:          expr.Filter(),
-		ProjectionExpression:      expr.Projection(),
-		TableName:                 t.table.Name,
-	}
+// 	params := &dynamodb.ScanInput{
+// 		ExpressionAttributeNames:  expr.Names(),
+// 		ExpressionAttributeValues: expr.Values(),
+// 		FilterExpression:          expr.Filter(),
+// 		ProjectionExpression:      expr.Projection(),
+// 		TableName:                 t.table.Name,
+// 	}
 
-	result, err := t.table.DynamoDB.Scan(params)
-	if err != nil {
-		return nil, err
-	}
+// 	result, err := t.table.DynamoDB.Scan(params)
+// 	if err != nil {
+// 		return nil, err
+// 	}
 
-	var items []TransactionItem
+// 	var items []TransactionItem
 
-	for _, i := range result.Items {
-		var item TransactionItem
-		err = dynamodbattribute.UnmarshalMap(i, &item)
-		if err != nil {
-			return nil, err
-		}
-		items = append(items, item)
-	}
+// 	for _, i := range result.Items {
+// 		var item TransactionItem
+// 		err = dynamodbattribute.UnmarshalMap(i, &item)
+// 		if err != nil {
+// 			return nil, err
+// 		}
+// 		items = append(items, item)
+// 	}
 
-	return items, nil
-}
+// 	return items, nil
+// }

--- a/server/internal/ddb/transactions.go
+++ b/server/internal/ddb/transactions.go
@@ -12,14 +12,18 @@ import (
 type TransactionItem struct {
 	PK         string `json:"PK"`
 	SK         string `json:"SK"`
+	EntityType string `json:"EntityType"`
 	ID         string `json:"ID"`
 	UserID     string `json:"UserID"`
-	EntityType string `json:"EntityType"`
 	GSI1PK     string `json:"GSI1PK"`
 	GSI1SK     string `json:"GSI1SK"`
 }
 
-const TransactionKeyPrefix = "txn"
+const (
+	TransactionKeyPrefix  = "txn"
+	transactionEntityType = "transaction"
+	allTxnKey             = "transactions"
+)
 
 type TransactionsTable interface {
 	Get(userID, transactionID string) (*TransactionItem, error)
@@ -72,8 +76,6 @@ func (t *transactionsTable) Delete(userID, txnID string) error {
 	txnKey := fmt.Sprintf("%s#%s", TransactionKeyPrefix, txnID)
 	return t.table.DeleteItem(attributes.String(userKey), attributes.String(txnKey))
 }
-
-const allTxnKey = "transactions"
 
 func (t *transactionsTable) GetAll() ([]TransactionItem, error) {
 	options := []option.QueryInput{

--- a/server/internal/ddb/transactions_test.go
+++ b/server/internal/ddb/transactions_test.go
@@ -59,9 +59,9 @@ func TestTransactionTable(t *testing.T) {
 	// assert.Contains(itemsGot, *item)
 
 	// get the transactions by username
-	// itemsGot, err := transactions.GetByUserID(testED.UserID)
-	// assert.NoError(err)
-	// assert.Contains(itemsGot, *item)
+	itemsGot, err := transactions.GetByUserID(item.UserID)
+	assert.NoError(err)
+	assert.Contains(itemsGot, *item)
 
 	// the item is successfully deleted
 	err = transactions.Delete(item.UserID, item.ID)

--- a/server/internal/ddb/transactions_test.go
+++ b/server/internal/ddb/transactions_test.go
@@ -33,6 +33,8 @@ func TestTransactionTable(t *testing.T) {
 		ID:         "test-txn-id",
 		UserID:     "test-user-id",
 		EntityType: "transaction",
+		GSI1PK:     "transactions",
+		GSI1SK:     "txn#test-txn-id",
 	}
 
 	// no error raised the first time
@@ -53,13 +55,13 @@ func TestTransactionTable(t *testing.T) {
 	assert.Equal(item, got)
 
 	// get all transactions
-	// itemsGot, err := transactions.GetAll()
-	// assert.NoError(err)
-	// assert.Len(itemsGot, 1)
-	// assert.Contains(itemsGot, *item)
+	itemsGot, err := transactions.GetAll()
+	assert.NoError(err)
+	assert.Len(itemsGot, 1)
+	assert.Contains(itemsGot, *item)
 
 	// get the transactions by username
-	itemsGot, err := transactions.GetByUserID(item.UserID)
+	itemsGot, err = transactions.GetByUserID(item.UserID)
 	assert.NoError(err)
 	assert.Contains(itemsGot, *item)
 

--- a/server/internal/ddb/transactions_test.go
+++ b/server/internal/ddb/transactions_test.go
@@ -24,7 +24,7 @@ func TestTransactionTable(t *testing.T) {
 	transactions := NewTxnRepository(tbl)
 
 	// retrieving a non-existent item will give an error
-	_, err = transactions.Get("non-existent-user", "non-existent-item")
+	_, err = transactions.Get("non-existent-item")
 	assert.EqualError(err, table.ErrItemNotFound.Error())
 
 	item := &TransactionItem{
@@ -50,7 +50,7 @@ func TestTransactionTable(t *testing.T) {
 	assert.EqualError(err, ErrConflict.Error())
 
 	// the item is successfully retrieved
-	got, err := transactions.Get(item.UserID, item.ID)
+	got, err := transactions.Get(item.ID)
 	assert.NoError(err)
 	assert.Equal(item, got)
 
@@ -68,6 +68,6 @@ func TestTransactionTable(t *testing.T) {
 	// the item is successfully deleted
 	err = transactions.Delete(item.UserID, item.ID)
 	assert.NoError(err)
-	_, err = transactions.Get(item.UserID, item.ID)
+	_, err = transactions.Get(item.ID)
 	assert.EqualError(err, table.ErrItemNotFound.Error())
 }

--- a/server/internal/ddb/transactions_test.go
+++ b/server/internal/ddb/transactions_test.go
@@ -14,7 +14,7 @@ func TestTransactionTable(t *testing.T) {
 	dynamodb := NewDynamoDBLocalAPI()
 
 	// create the table in the local test database
-	err := CreateExpenseusTable(dynamodb, testTransactionsTableName)
+	err := CreateTestTable(dynamodb, testTransactionsTableName)
 	if err != nil {
 		t.Logf("table could not be created: %v", err)
 	}

--- a/server/internal/ddb/transactions_test.go
+++ b/server/internal/ddb/transactions_test.go
@@ -21,7 +21,7 @@ func TestTransactionTable(t *testing.T) {
 	defer DeleteTable(dynamodb, testTransactionsTableName)
 	tbl := table.New(dynamodb, testTransactionsTableName)
 	// create the transactions table instance
-	transactions := NewTransactionsTable(tbl)
+	transactions := NewTxnRepository(tbl)
 
 	// retrieving a non-existent item will give an error
 	_, err = transactions.Get("non-existent-user", "non-existent-item")

--- a/server/internal/ddb/users.go
+++ b/server/internal/ddb/users.go
@@ -30,22 +30,19 @@ type users struct {
 }
 
 const (
-	HashKey        = "PK"
-	RangeKey       = "SK"
-	UserKeyPrefix  = "user"
-	UserEntityType = "user"
+	userKeyPrefix  = "user"
+	userEntityType = "user"
 	allUsersKey    = "users"
-	GSI1PK         = "GSI1PK"
 )
 
 func NewUsersTable(t *table.Table) UsersTable {
-	t.WithHashKey(HashKey, dynamodb.ScalarAttributeTypeS)
-	t.WithRangeKey(RangeKey, dynamodb.ScalarAttributeTypeS)
+	t.WithHashKey(tablePrimaryKey, dynamodb.ScalarAttributeTypeS)
+	t.WithRangeKey(tableSortKey, dynamodb.ScalarAttributeTypeS)
 	return &users{table: t}
 }
 
 func (u *users) Get(id string) (UserItem, error) {
-	userKey := fmt.Sprintf("%s#%s", UserKeyPrefix, id)
+	userKey := fmt.Sprintf("%s#%s", userKeyPrefix, id)
 	item := &UserItem{}
 	err := u.table.GetItem(attributes.String(userKey), attributes.String(userKey), item)
 	if err != nil {
@@ -57,7 +54,7 @@ func (u *users) Get(id string) (UserItem, error) {
 func (u *users) GetAll() ([]UserItem, error) {
 	options := []option.QueryInput{
 		option.Index("GSI1"),
-		option.QueryExpressionAttributeName(GSI1PK, "#GSI1PK"),
+		option.QueryExpressionAttributeName(gsi1PrimaryKey, "#GSI1PK"),
 		option.QueryExpressionAttributeValue(":usersKey", attributes.String(allUsersKey)),
 		option.QueryKeyConditionExpression("#GSI1PK = :usersKey"),
 	}
@@ -83,6 +80,6 @@ func (u *users) PutIfNotExists(item UserItem) error {
 }
 
 func (u *users) Delete(id string) error {
-	userKey := fmt.Sprintf("%s#%s", UserKeyPrefix, id)
+	userKey := fmt.Sprintf("%s#%s", userKeyPrefix, id)
 	return u.table.DeleteItem(attributes.String(userKey), attributes.String(userKey))
 }

--- a/server/internal/ddb/users.go
+++ b/server/internal/ddb/users.go
@@ -33,7 +33,6 @@ const (
 	HashKey        = "PK"
 	RangeKey       = "SK"
 	UserKeyPrefix  = "user"
-	usersKey       = "users"
 	UserEntityType = "user"
 	allUsersKey    = "users"
 	GSI1PK         = "GSI1PK"

--- a/server/internal/ddb/users.go
+++ b/server/internal/ddb/users.go
@@ -14,6 +14,8 @@ type UserItem struct {
 	SK         string `json:"SK"`
 	EntityType string `json:"EntityType"`
 	ID         string `json:"ID"`
+	Username   string `json:"Username"`
+	Name       string `json:"Name"`
 	GSI1PK     string `json:"GSI1PK"`
 	GSI1SK     string `json:"GSI1SK"`
 }

--- a/server/internal/ddb/users.go
+++ b/server/internal/ddb/users.go
@@ -58,7 +58,7 @@ func (u *users) GetAll() ([]UserItem, error) {
 	options := []option.QueryInput{
 		option.Index("GSI1"),
 		option.QueryExpressionAttributeName(GSI1PK, "#GSI1PK"),
-		option.QueryExpressionAttributeValue(":usersKey", attributes.String(usersKey)),
+		option.QueryExpressionAttributeValue(":usersKey", attributes.String(allUsersKey)),
 		option.QueryKeyConditionExpression("#GSI1PK = :usersKey"),
 	}
 

--- a/server/internal/ddb/users.go
+++ b/server/internal/ddb/users.go
@@ -30,11 +30,13 @@ type users struct {
 }
 
 const (
-	HashKey       = "PK"
-	RangeKey      = "SK"
-	UserKeyPrefix = "user"
-	UsersKey      = "users"
-	GSI1PK        = "GSI1PK"
+	HashKey        = "PK"
+	RangeKey       = "SK"
+	UserKeyPrefix  = "user"
+	usersKey       = "users"
+	UserEntityType = "user"
+	allUsersKey    = "users"
+	GSI1PK         = "GSI1PK"
 )
 
 func NewUsersTable(t *table.Table) UsersTable {
@@ -57,7 +59,7 @@ func (u *users) GetAll() ([]UserItem, error) {
 	options := []option.QueryInput{
 		option.Index("GSI1"),
 		option.QueryExpressionAttributeName(GSI1PK, "#GSI1PK"),
-		option.QueryExpressionAttributeValue(":usersKey", attributes.String(UsersKey)),
+		option.QueryExpressionAttributeValue(":usersKey", attributes.String(usersKey)),
 		option.QueryKeyConditionExpression("#GSI1PK = :usersKey"),
 	}
 

--- a/server/internal/ddb/users.go
+++ b/server/internal/ddb/users.go
@@ -42,9 +42,9 @@ func NewUsersTable(t *table.Table) UsersTable {
 }
 
 func (u *users) Get(id string) (UserItem, error) {
-	userKey := fmt.Sprintf("%s#%s", userKeyPrefix, id)
+	key := makeUserIDKey(id)
 	item := &UserItem{}
-	err := u.table.GetItem(attributes.String(userKey), attributes.String(userKey), item)
+	err := u.table.GetItem(attributes.String(key), attributes.String(key), item)
 	if err != nil {
 		return UserItem{}, err
 	}
@@ -80,6 +80,10 @@ func (u *users) PutIfNotExists(item UserItem) error {
 }
 
 func (u *users) Delete(id string) error {
-	userKey := fmt.Sprintf("%s#%s", userKeyPrefix, id)
-	return u.table.DeleteItem(attributes.String(userKey), attributes.String(userKey))
+	key := makeUserIDKey(id)
+	return u.table.DeleteItem(attributes.String(key), attributes.String(key))
+}
+
+func makeUserIDKey(id string) string {
+	return fmt.Sprintf("%s#%s", userKeyPrefix, id)
 }

--- a/server/internal/ddb/users_test.go
+++ b/server/internal/ddb/users_test.go
@@ -31,6 +31,8 @@ func TestUsersTable(t *testing.T) {
 		SK:         "user#test",
 		EntityType: "user",
 		ID:         "test",
+		GSI1PK:     "users",
+		GSI1SK:     "user#test",
 	}
 
 	err = users.PutIfNotExists(user)
@@ -44,6 +46,12 @@ func TestUsersTable(t *testing.T) {
 	got, err := users.Get(user.ID)
 	assert.NoError(err)
 	assert.Equal(user, got)
+
+	// retrieve all users
+	usersGot, err := users.GetAll()
+	assert.NoError(err)
+	assert.Len(usersGot, 1)
+	assert.Contains(usersGot, user)
 
 	err = users.Delete(user.ID)
 	assert.NoError(err)

--- a/server/internal/ddb/users_test.go
+++ b/server/internal/ddb/users_test.go
@@ -20,7 +20,7 @@ func TestUsersTable(t *testing.T) {
 	defer DeleteTable(dynamodb, testUsersTableName)
 
 	tbl := table.New(dynamodb, testUsersTableName)
-	users := NewUsersTable(tbl)
+	users := NewUserRepository(tbl)
 
 	// retrieving a non-existent user will give an error
 	_, err = users.Get("non-existent-user")

--- a/server/internal/ddb/users_test.go
+++ b/server/internal/ddb/users_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/nabeken/aws-go-dynamodb/table"
-	"github.com/saifahn/expenseus/internal/app"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -14,7 +13,7 @@ func TestUsersTable(t *testing.T) {
 	assert := assert.New(t)
 	dynamodb := NewDynamoDBLocalAPI()
 
-	err := CreateTestTable(dynamodb, testUsersTableName)
+	err := CreateExpenseusTable(dynamodb, testUsersTableName)
 	if err != nil {
 		t.Logf("table could not be created: %v", err)
 	}
@@ -28,11 +27,10 @@ func TestUsersTable(t *testing.T) {
 	assert.EqualError(err, table.ErrItemNotFound.Error())
 
 	user := UserItem{
-		User: app.User{
-			ID:       "test-user",
-			Name:     "Testman",
-			Username: "testman-23",
-		},
+		PK:         "user#test",
+		SK:         "user#test",
+		EntityType: "user",
+		ID:         "test",
 	}
 
 	err = users.PutIfNotExists(user)
@@ -44,17 +42,6 @@ func TestUsersTable(t *testing.T) {
 
 	// the user can be retrieved
 	got, err := users.Get(user.ID)
-	assert.NoError(err)
-	assert.Equal(user, got)
-
-	// retrieve all users
-	usersGot, err := users.GetAll()
-	assert.NoError(err)
-	assert.Len(usersGot, 1)
-	assert.Contains(usersGot, user)
-
-	// get a user by username
-	got, err = users.GetByUsername(user.Username)
 	assert.NoError(err)
 	assert.Equal(user, got)
 

--- a/server/internal/ddb/users_test.go
+++ b/server/internal/ddb/users_test.go
@@ -13,7 +13,7 @@ func TestUsersTable(t *testing.T) {
 	assert := assert.New(t)
 	dynamodb := NewDynamoDBLocalAPI()
 
-	err := CreateExpenseusTable(dynamodb, testUsersTableName)
+	err := CreateTestTable(dynamodb, testUsersTableName)
 	if err != nil {
 		t.Logf("table could not be created: %v", err)
 	}

--- a/server/internal/integration_test/integration_test.go
+++ b/server/internal/integration_test/integration_test.go
@@ -13,28 +13,19 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const usersTableName = "integtest-users-table"
-const transactionsTableName = "integtest-transactions-table"
+const testTableName = "expenseus-integ-test"
 
 func setUpDB(d dynamodbiface.DynamoDBAPI) (app.Store, error) {
-	err := ddb.CreateTestTable(d, usersTableName)
-	if err != nil {
-		return nil, err
-	}
-	err = ddb.CreateTestTable(d, transactionsTableName)
+	err := ddb.CreateTestTable(d, testTableName)
 	if err != nil {
 		return nil, err
 	}
 
-	return ddb.New(d, usersTableName, transactionsTableName), nil
+	return ddb.New(d, testTableName), nil
 }
 
 func tearDownDB(d dynamodbiface.DynamoDBAPI) error {
-	err := ddb.DeleteTable(d, usersTableName)
-	if err != nil {
-		return err
-	}
-	err = ddb.DeleteTable(d, transactionsTableName)
+	err := ddb.DeleteTable(d, testTableName)
 	if err != nil {
 		return err
 	}
@@ -240,8 +231,7 @@ func TestCreatingTransactionsAndRetrievingThem(t *testing.T) {
 		assert.Equal(transactionsGot[0], got)
 	})
 
-	// maybe just by user ID is better
-	t.Run("transactions can be retrieved by username", func(t *testing.T) {
+	t.Run("transactions can be retrieved by user ID", func(t *testing.T) {
 		router, tearDownDB := setUpTestServer(t)
 		defer tearDownDB(t)
 		assert := assert.New(t)
@@ -250,7 +240,7 @@ func TestCreatingTransactionsAndRetrievingThem(t *testing.T) {
 		wantedTransactionDetails := app.TestSeanTransactionDetails
 		createTestTransaction(t, router, wantedTransactionDetails, app.TestSeanUser.ID)
 
-		request := app.NewGetTransactionsByUsernameRequest(app.TestSeanUser.Username)
+		request := app.NewGetTransactionsByUserRequest(app.TestSeanUser.ID)
 		request.AddCookie(&app.ValidCookie)
 		response := httptest.NewRecorder()
 		router.ServeHTTP(response, request)

--- a/server/internal/router/router.go
+++ b/server/internal/router/router.go
@@ -34,13 +34,13 @@ func Init(a *app.App) *chi.Mux {
 			r.Get("/", a.GetAllTransactions)
 			r.Post("/", a.CreateTransaction)
 
-			r.Route("/user/{username}", func(r chi.Router) {
-				r.Use(UsernameCtx)
-				r.Get("/", a.GetTransactionsByUsername)
+			r.Route("/user/{userID}", func(r chi.Router) {
+				r.Use(userIDCtx)
+				r.Get("/", a.GetTransactionsByUser)
 			})
 
 			r.Route("/{transactionID}", func(r chi.Router) {
-				r.Use(TransactionIDCtx)
+				r.Use(transactionIDCtx)
 				r.Get("/", a.GetTransaction)
 			})
 		})
@@ -52,7 +52,7 @@ func Init(a *app.App) *chi.Mux {
 			r.Get("/self", a.GetSelf)
 
 			r.Route("/{userID}", func(r chi.Router) {
-				r.Use(UserIDCtx)
+				r.Use(userIDCtx)
 				r.Get("/", a.GetUser)
 			})
 		})
@@ -66,7 +66,7 @@ func Init(a *app.App) *chi.Mux {
 }
 
 // Gets the ID from the URL and adds it to the id context for the request.
-func TransactionIDCtx(next http.Handler) http.Handler {
+func transactionIDCtx(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		transactionID := chi.URLParam(r, "transactionID")
 		ctx := context.WithValue(r.Context(), app.CtxKeyTransactionID, transactionID)
@@ -74,17 +74,8 @@ func TransactionIDCtx(next http.Handler) http.Handler {
 	})
 }
 
-// Gets the username from the URL and adds it to the user context for the request.
-func UsernameCtx(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		username := chi.URLParam(r, "username")
-		ctx := context.WithValue(r.Context(), app.CtxKeyUsername, username)
-		next.ServeHTTP(rw, r.WithContext(ctx))
-	})
-}
-
 // Gets the UserID from the URL and adds it to the UserID context for the request.
-func UserIDCtx(next http.Handler) http.Handler {
+func userIDCtx(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		id := chi.URLParam(r, "userID")
 		ctx := context.WithValue(r.Context(), app.CtxKeyUserID, id)


### PR DESCRIPTION
## Overview

- Previously, we were keeping the data stored in two separate tables for User and Transaction. This was modeled after how a RDBMS would handle the data. For a more scalable solution, it has been combined into one table - the optimal way of using DynamoDB.
- GetTransactionsByUsername has been changed to GetTransactionsByUser (ID for now, could do username in the future)
- UserItem and TransactionItem have been extended to hold more fields, representing the Users and Transactions in the db.
- The front end has not been updated with the changes, and will be handled in a future update.