### PR TITLE
Get unsettled amounts owed for shared transactions

### DIFF
--- a/client/components/LayoutTracker.tsx
+++ b/client/components/LayoutTracker.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { Tracker } from 'pages/shared/trackers';
 import useSWR from 'swr';
@@ -21,6 +22,20 @@ export default function TrackerLayout({ children }) {
           {tracker.users.map((user) => (
             <p key={user}>{user}</p>
           ))}
+          <nav className="mt-4">
+            <ul className="flex">
+              <li className="flex">
+                <Link href={`/shared/trackers/${trackerId}`}>
+                  <a className="border-2 p-2">Transactions</a>
+                </Link>
+              </li>
+              <li className="flex">
+                <Link href={`/shared/trackers/${trackerId}/unsettled-txns`}>
+                  <a className="ml-4 border-2 p-2">Unsettled</a>
+                </Link>
+              </li>
+            </ul>
+          </nav>
           {children}
         </>
       )}

--- a/client/components/LayoutTracker.tsx
+++ b/client/components/LayoutTracker.tsx
@@ -1,0 +1,29 @@
+import { useRouter } from 'next/router';
+import { Tracker } from 'pages/shared/trackers';
+import useSWR from 'swr';
+import SharedLayout from './LayoutShared';
+
+export default function TrackerLayout({ children }) {
+  const router = useRouter();
+  const { trackerId } = router.query;
+  const { data: tracker, error } = useSWR<Tracker>(
+    `${process.env.NEXT_PUBLIC_API_BASE_URL}/trackers/${trackerId}`,
+  );
+
+  return (
+    <SharedLayout>
+      {error && <div>Failed to load</div>}
+      {!error && !tracker && <div>Loading tracker information...</div>}
+      {tracker && (
+        <>
+          <h2 className="mt-8 text-2xl">{tracker.name}</h2>
+          <h3 className="mt-2">{tracker.id}</h3>
+          {tracker.users.map((user) => (
+            <p key={user}>{user}</p>
+          ))}
+          {children}
+        </>
+      )}
+    </SharedLayout>
+  );
+}

--- a/client/components/SharedTxnCreateForm.tsx
+++ b/client/components/SharedTxnCreateForm.tsx
@@ -43,6 +43,8 @@ export default function SharedTxnCreateForm({ tracker }: Props) {
       participants: '',
       category: 'unspecified.unspecified',
       details: '',
+      // TODO: support more than two users
+      split: `${tracker.users[0]}:0.50,${tracker.users[1]}:0.50`,
     },
   });
 

--- a/client/components/SharedTxnFormBase.tsx
+++ b/client/components/SharedTxnFormBase.tsx
@@ -6,7 +6,7 @@ import {
   subcategories,
 } from 'data/categories';
 import { Tracker } from 'pages/shared/trackers';
-import React from 'react';
+import React, { useState } from 'react';
 import { UseFormRegister } from 'react-hook-form';
 import { plainDateStringToEpochSec } from 'utils/dates';
 
@@ -14,11 +14,12 @@ export type SharedTxnFormInputs = {
   location: string;
   amount: number;
   date: string;
-  settled?: boolean;
   participants: string;
   payer: string;
   details: string;
   category: SubcategoryKey;
+  settled?: boolean;
+  split?: string;
 };
 
 export function createSharedTxnFormData(data: SharedTxnFormInputs) {
@@ -33,6 +34,7 @@ export function createSharedTxnFormData(data: SharedTxnFormInputs) {
 
   const unixDate = plainDateStringToEpochSec(data.date);
   formData.append('date', unixDate.toString());
+  formData.append('split', data.split);
   return formData;
 }
 
@@ -51,6 +53,8 @@ export default function SharedTxnFormBase({
   onSubmit,
   children,
 }: Props) {
+  const [hasCustomSplit, setHasCustomSplit] = useState(false);
+
   return (
     <form
       onSubmit={(e) => {
@@ -156,6 +160,27 @@ export default function SharedTxnFormBase({
           id="details"
         />
       </div>
+      <div className="mt-4">
+        <label className="block font-semibold" htmlFor="details">
+          Custom split?
+        </label>
+        <input
+          type="checkbox"
+          checked={hasCustomSplit}
+          onChange={(e) => {
+            setHasCustomSplit(e.target.checked);
+          }}
+        />
+      </div>
+      {hasCustomSplit && (
+        <div className="mt-4">
+          <input
+            {...register('split')}
+            className="mt-2 w-full appearance-none rounded border py-2 px-3 leading-tight focus:outline-none focus:ring"
+            type="text"
+          />
+        </div>
+      )}
       {children}
     </form>
   );

--- a/client/components/SharedTxnReadUpdateForm.tsx
+++ b/client/components/SharedTxnReadUpdateForm.tsx
@@ -43,6 +43,12 @@ export default function SharedTxnReadUpdateForm({
   onCancel,
 }: Props) {
   const { mutate } = useSWRConfig();
+
+  let userSplits = [];
+  for (const userSplit of Object.entries(txn.split)) {
+    userSplits.push(`${userSplit[0]}:${userSplit[1]}`);
+  }
+
   const { register, handleSubmit, formState } = useForm<SharedTxnFormInputs>({
     shouldUseNativeValidation: true,
     defaultValues: {
@@ -52,6 +58,7 @@ export default function SharedTxnReadUpdateForm({
       settled: !txn.unsettled,
       category: txn.category,
       details: txn.details,
+      split: userSplits.join(','),
     },
   });
 

--- a/client/pages/shared/trackers/[trackerId].tsx
+++ b/client/pages/shared/trackers/[trackerId].tsx
@@ -13,11 +13,14 @@ export interface SharedTxn {
   location: string;
   amount: number;
   date: number;
-  unsettled?: boolean;
   participants: string[];
   tracker: string;
   category: SubcategoryKey;
   details: string;
+  unsettled?: boolean;
+  split?: {
+    [userId: string]: number;
+  };
 }
 
 async function deleteSharedTxn(txn: SharedTxn) {

--- a/client/pages/shared/trackers/[trackerId]/index.tsx
+++ b/client/pages/shared/trackers/[trackerId]/index.tsx
@@ -1,4 +1,4 @@
-import SharedLayout from 'components/LayoutShared';
+import TrackerLayout from 'components/LayoutTracker';
 import SharedTxnCreateForm from 'components/SharedTxnCreateForm';
 import SharedTxnReadUpdateForm from 'components/SharedTxnReadUpdateForm';
 import { SubcategoryKey } from 'data/categories';
@@ -6,7 +6,7 @@ import { useRouter } from 'next/router';
 import React, { useState } from 'react';
 import useSWR, { mutate } from 'swr';
 import { epochSecToLocaleString } from 'utils/dates';
-import { Tracker } from '.';
+import { Tracker } from '..';
 
 export interface SharedTxn {
   id: string;
@@ -94,53 +94,44 @@ export default function TrackerPage() {
   );
 
   return (
-    <SharedLayout>
-      {error && <div>Failed to load</div>}
-      {!error && !tracker && <div>Loading tracker information...</div>}
-      {tracker && (
-        <>
-          <h2 className="mt-8 text-2xl">{tracker.name}</h2>
-          <h3 className="mt-2">{tracker.id}</h3>
-          {tracker.users.map((user) => (
-            <p key={user}>{user}</p>
-          ))}
-          {selectedTxn ? (
+    <TrackerLayout>
+      {selectedTxn ? (
+        <div className="mt-4">
+          <SharedTxnReadUpdateForm
+            txn={selectedTxn}
+            tracker={tracker}
+            onApply={() => setSelectedTxn(null)}
+            onCancel={() => setSelectedTxn(null)}
+          />
+        </div>
+      ) : (
+        tracker && (
+          <>
             <div className="mt-4">
-              <SharedTxnReadUpdateForm
-                txn={selectedTxn}
-                tracker={tracker}
-                onApply={() => setSelectedTxn(null)}
-                onCancel={() => setSelectedTxn(null)}
-              />
+              <SharedTxnCreateForm tracker={tracker} />
             </div>
-          ) : (
-            <>
-              <div className="mt-4">
-                <SharedTxnCreateForm tracker={tracker} />
-              </div>
-              <div className="mt-8">
-                <h3 className="mt-4 text-2xl">Transactions</h3>
-                {sharedTxnsError && <div>Failed to load</div>}
-                {sharedTxns === null && (
-                  <div>Loading list of transactions...</div>
-                )}
-                {sharedTxns && sharedTxns.length === 0 && (
-                  <div>There are no transactions here yet</div>
-                )}
-                {sharedTxns &&
-                  sharedTxns.map((txn) => (
-                    <SharedTxnOne
-                      txn={txn}
-                      onTxnClick={setSelectedTxn}
-                      key={txn.id}
-                      tracker={tracker}
-                    />
-                  ))}
-              </div>
-            </>
-          )}
-        </>
+            <div className="mt-8">
+              <h3 className="mt-4 text-2xl">Transactions</h3>
+              {sharedTxnsError && <div>Failed to load</div>}
+              {sharedTxns === null && (
+                <div>Loading list of transactions...</div>
+              )}
+              {sharedTxns && sharedTxns.length === 0 && (
+                <div>There are no transactions here yet</div>
+              )}
+              {sharedTxns &&
+                sharedTxns.map((txn) => (
+                  <SharedTxnOne
+                    txn={txn}
+                    onTxnClick={setSelectedTxn}
+                    key={txn.id}
+                    tracker={tracker}
+                  />
+                ))}
+            </div>
+          </>
+        )
       )}
-    </SharedLayout>
+    </TrackerLayout>
   );
 }

--- a/client/pages/shared/trackers/[trackerId]/unsettled-txns.tsx
+++ b/client/pages/shared/trackers/[trackerId]/unsettled-txns.tsx
@@ -1,0 +1,32 @@
+import TrackerLayout from 'components/LayoutTracker';
+import { useRouter } from 'next/router';
+import useSWR from 'swr';
+import { SharedTxn } from '.';
+
+type UnsettledResponse = {
+  transactions: SharedTxn[];
+  debtor: string;
+  debtee: string;
+  amountOwed: number;
+};
+
+export default function UnsettledTxnPage() {
+  const router = useRouter();
+  const { trackerId } = router.query;
+  const { data: response, error } = useSWR<UnsettledResponse>(
+    `${process.env.NEXT_PUBLIC_API_BASE_URL}/trackers/${trackerId}/transactions/unsettled`,
+  );
+
+  return (
+    <TrackerLayout>
+      {error && <div>Error loading unsettled transactions</div>}
+      {response === null && <div>Loading unsettled transactions</div>}
+      {response && (
+        <div className="mt-4">
+          {response.debtor} owes {response.debtee} {response.amountOwed} for{' '}
+          {response.transactions.length} transactions
+        </div>
+      )}
+    </TrackerLayout>
+  );
+}

--- a/server/internal/app/sharedtxns.go
+++ b/server/internal/app/sharedtxns.go
@@ -207,9 +207,6 @@ type UnsettledResponse struct {
 	AmountOwed float64             `json:"amountOwed"`
 }
 
-// starting value for split as 0 is the same as the zero value for a float
-const STARTING_SPLIT = 8.88
-
 func CalculateDebts(currentUser string, txns []SharedTransaction) UnsettledResponse {
 	defaultSplit := 0.5
 	var otherUser string
@@ -227,13 +224,8 @@ func CalculateDebts(currentUser string, txns []SharedTransaction) UnsettledRespo
 			}
 		}
 
-		// start with a non-real split as the default
-		split := STARTING_SPLIT
-		currentUserSplit := t.Split[currentUser]
-		otherUserSplit := t.Split[otherUser]
-		// only when both are the zero value do we use the default split, to allow
-		// for a user-defined 0.0 custom split
-		if currentUserSplit == 0 && otherUserSplit == 0 {
+		var split float64
+		if t.Split == nil {
 			split = defaultSplit
 		}
 
@@ -243,12 +235,12 @@ func CalculateDebts(currentUser string, txns []SharedTransaction) UnsettledRespo
 			// Split represents the proportion each participant will pay for a purchase
 			// so when calculating the debt, it is the inverse proportion (and is equal to
 			// the other person's proportion) that is used
-			if split == STARTING_SPLIT {
+			if split != defaultSplit {
 				split = t.Split[otherUser]
 			}
 			total += float64(t.Amount) * split
 		} else {
-			if split == STARTING_SPLIT {
+			if split != defaultSplit {
 				split = t.Split[currentUser]
 			}
 			total -= float64(t.Amount) * split

--- a/server/internal/app/sharedtxns.go
+++ b/server/internal/app/sharedtxns.go
@@ -217,7 +217,6 @@ func totalOwed(currentUser string, txns []SharedTransaction) UnsettledResponse {
 		Debtee:     currentUser,
 		AmountOwed: total,
 	}
-
 }
 
 // GetUnsettledTxnsByTracker handles a HTTP request to get transactions that

--- a/server/internal/app/sharedtxns.go
+++ b/server/internal/app/sharedtxns.go
@@ -188,7 +188,7 @@ type UnsettledResponse struct {
 	AmountOwed float64             `json:"amountOwed"`
 }
 
-func TotalOwed(currentUser string, txns []SharedTransaction) UnsettledResponse {
+func CalculateDebts(currentUser string, txns []SharedTransaction) UnsettledResponse {
 	defaultSplit := 0.5
 	var otherUser string
 	var total float64
@@ -234,7 +234,7 @@ func (a *App) GetUnsettledTxnsByTracker(w http.ResponseWriter, r *http.Request) 
 		http.Error(w, fmt.Sprintf("something went wrong getting unsettled shared transactions from tracker: %v", err.Error()), http.StatusInternalServerError)
 		return
 	}
-	totals := TotalOwed(userID, transactions)
+	totals := CalculateDebts(userID, transactions)
 
 	w.Header().Set("content-type", jsonContentType)
 	err = json.NewEncoder(w).Encode(totals)

--- a/server/internal/app/sharedtxns.go
+++ b/server/internal/app/sharedtxns.go
@@ -188,7 +188,7 @@ type UnsettledResponse struct {
 	AmountOwed float64             `json:"amountOwed"`
 }
 
-func totalOwed(currentUser string, txns []SharedTransaction) UnsettledResponse {
+func TotalOwed(currentUser string, txns []SharedTransaction) UnsettledResponse {
 	defaultSplit := 0.5
 	var otherUser string
 	var total float64
@@ -234,7 +234,7 @@ func (a *App) GetUnsettledTxnsByTracker(w http.ResponseWriter, r *http.Request) 
 		http.Error(w, fmt.Sprintf("something went wrong getting unsettled shared transactions from tracker: %v", err.Error()), http.StatusInternalServerError)
 		return
 	}
-	totals := totalOwed(userID, transactions)
+	totals := TotalOwed(userID, transactions)
 
 	w.Header().Set("content-type", jsonContentType)
 	err = json.NewEncoder(w).Encode(totals)

--- a/server/internal/app/sharedtxns_test.go
+++ b/server/internal/app/sharedtxns_test.go
@@ -267,6 +267,15 @@ func TestCalculateDebts(t *testing.T) {
 			Amount:       2000,
 			Participants: participants,
 		},
+		{
+			Payer:        firstUser,
+			Amount:       1000,
+			Participants: participants,
+			Split: map[string]float64{
+				firstUser:  0.67,
+				secondUser: 0.33,
+			},
+		},
 	}
 
 	tests := map[string]struct {
@@ -285,9 +294,14 @@ func TestCalculateDebts(t *testing.T) {
 			wantAmount:  -500,
 		},
 		"for two transactions": {
-			txns:        txns,
+			txns:        txns[0:2],
 			currentUser: firstUser,
 			wantAmount:  -500,
+		},
+		"for a transaction with a custom split": {
+			txns:        txns[2:3],
+			currentUser: firstUser,
+			wantAmount:  330,
 		},
 	}
 	for name, tc := range tests {

--- a/server/internal/app/sharedtxns_test.go
+++ b/server/internal/app/sharedtxns_test.go
@@ -281,53 +281,72 @@ func TestCalculateDebts(t *testing.T) {
 			Amount:       1000,
 			Participants: participants,
 			Split: map[string]float64{
-				firstUser:  1.0,
-				secondUser: 0.0,
+				firstUser:  1,
+				secondUser: 0,
+			},
+		},
+		{
+			Payer:        secondUser,
+			Amount:       2000,
+			Participants: participants,
+			Split: map[string]float64{
+				firstUser:  1,
+				secondUser: 0,
 			},
 		},
 	}
 
 	tests := map[string]struct {
-		txns        []app.SharedTransaction
-		currentUser string
-		wantAmount  float64
+		txns           []app.SharedTransaction
+		currentUser    string
+		wantAmountOwed float64
 	}{
 		"for one transaction where the payer is the current user": {
-			txns:        txns[0:1],
-			currentUser: firstUser,
-			wantAmount:  500,
+			txns:           txns[0:1],
+			currentUser:    firstUser,
+			wantAmountOwed: 500,
 		},
 		"for one transaction, where the payer is not the current user": {
-			txns:        txns[0:1],
-			currentUser: secondUser,
-			wantAmount:  -500,
+			txns:           txns[0:1],
+			currentUser:    secondUser,
+			wantAmountOwed: -500,
 		},
 		"for two transactions": {
-			txns:        txns[0:2],
-			currentUser: firstUser,
-			wantAmount:  -500,
+			txns:           txns[0:2],
+			currentUser:    firstUser,
+			wantAmountOwed: -500,
 		},
 		"for a transaction with a custom split": {
-			txns:        txns[2:3],
-			currentUser: firstUser,
-			wantAmount:  330,
+			txns:           txns[2:3],
+			currentUser:    firstUser,
+			wantAmountOwed: 330,
 		},
 		"for a transaction that is completely owed by and paid by the logged in user": {
-			txns:        txns[3:4],
-			currentUser: firstUser,
-			wantAmount:  0,
+			txns:           txns[3:4],
+			currentUser:    firstUser,
+			wantAmountOwed: 0,
 		},
 		"for a transaction that is completely owed by and paid by the other user": {
-			txns:        txns[3:4],
-			currentUser: secondUser,
-			wantAmount:  0,
+			txns:           txns[3:4],
+			currentUser:    secondUser,
+			wantAmountOwed: 0,
+		},
+		"for a transaction that is completely owed by the logged in user and paid by the other user": {
+			txns:           txns[4:5],
+			currentUser:    firstUser,
+			wantAmountOwed: -2000,
+		},
+		"for a transaction that is completely paid by the logged in user and owed by the other user": {
+			txns:           txns[4:5],
+			currentUser:    secondUser,
+			wantAmountOwed: 2000,
 		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 			totals := app.CalculateDebts(tc.currentUser, tc.txns)
-			assert.Equal(tc.wantAmount, totals.AmountOwed)
+			assert.Equal(tc.wantAmountOwed, totals.AmountOwed)
 			assert.Equal(tc.currentUser, totals.Debtee)
 		})
 	}

--- a/server/internal/app/sharedtxns_test.go
+++ b/server/internal/app/sharedtxns_test.go
@@ -266,6 +266,8 @@ func TestGetUnsettledTxnsByTracker(t *testing.T) {
 		expectationsFn mock_app.MockAppFn
 		wantTxns       []app.SharedTransaction
 		wantCode       int
+		wantDebtor     string
+		wantDebtee     string
 	}{
 		"with an empty list of txns from the store, returns an empty list": {
 			trackerID: testTrackerID,
@@ -282,6 +284,9 @@ func TestGetUnsettledTxnsByTracker(t *testing.T) {
 			},
 			wantTxns: unsettledTxns,
 			wantCode: http.StatusOK,
+			// we have hardcoded user-01 as the logged in user in the test
+			wantDebtor: "user-02",
+			wantDebtee: "user-01",
 		},
 		"with a trackerID of a non-existent tracker, returns a 404": {
 			trackerID: "non-existent-trackerID",
@@ -313,6 +318,13 @@ func TestGetUnsettledTxnsByTracker(t *testing.T) {
 					t.Fatalf("error parsing response from server %q into UnsettledResponse, '%v'", response.Body, err)
 				}
 				assert.ElementsMatch(got.Txns, tc.wantTxns)
+
+				if tc.wantDebtor != "" {
+					assert.Equal(tc.wantDebtor, got.Debtor)
+				}
+				if tc.wantDebtee != "" {
+					assert.Equal(tc.wantDebtee, got.Debtee)
+				}
 			}
 		})
 	}

--- a/server/internal/app/sharedtxns_test.go
+++ b/server/internal/app/sharedtxns_test.go
@@ -252,7 +252,7 @@ func TestDeleteSharedTxn(t *testing.T) {
 	}
 }
 
-func TestTotalOwed(t *testing.T) {
+func TestCalculateDebts(t *testing.T) {
 	firstUser := "first-user"
 	secondUser := "second-user"
 	participants := []string{firstUser, secondUser}
@@ -293,7 +293,7 @@ func TestTotalOwed(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
-			totals := app.TotalOwed(tc.currentUser, tc.txns)
+			totals := app.CalculateDebts(tc.currentUser, tc.txns)
 			assert.Equal(tc.wantAmount, totals.AmountOwed)
 			assert.Equal(tc.currentUser, totals.Debtee)
 		})

--- a/server/internal/app/sharedtxns_test.go
+++ b/server/internal/app/sharedtxns_test.go
@@ -276,6 +276,15 @@ func TestCalculateDebts(t *testing.T) {
 				secondUser: 0.33,
 			},
 		},
+		{
+			Payer:        firstUser,
+			Amount:       1000,
+			Participants: participants,
+			Split: map[string]float64{
+				firstUser:  1.0,
+				secondUser: 0.0,
+			},
+		},
 	}
 
 	tests := map[string]struct {
@@ -302,6 +311,16 @@ func TestCalculateDebts(t *testing.T) {
 			txns:        txns[2:3],
 			currentUser: firstUser,
 			wantAmount:  330,
+		},
+		"for a transaction that is completely owed by and paid by the logged in user": {
+			txns:        txns[3:4],
+			currentUser: firstUser,
+			wantAmount:  0,
+		},
+		"for a transaction that is completely owed by and paid by the other user": {
+			txns:        txns[3:4],
+			currentUser: secondUser,
+			wantAmount:  0,
 		},
 	}
 	for name, tc := range tests {

--- a/server/internal/app/testing.go
+++ b/server/internal/app/testing.go
@@ -208,6 +208,15 @@ func MakeSharedTxnRequestPayload(txn SharedTransaction) (bytes.Buffer, string) {
 		unsettled = "true"
 	}
 
+	var splits []string
+	if txn.Split != nil {
+		for user, split := range txn.Split {
+			s := strconv.FormatFloat(split, 'E', -1, 64)
+			splits = append(splits, fmt.Sprintf("%s:%s", user, s))
+		}
+	}
+	splitString := strings.Join(splits, ",")
+
 	values := map[string]io.Reader{
 		"location": strings.NewReader(txn.Location),
 		"amount":   strings.NewReader(strconv.FormatInt(txn.Amount, 10)),
@@ -218,6 +227,7 @@ func MakeSharedTxnRequestPayload(txn SharedTransaction) (bytes.Buffer, string) {
 		"category":     strings.NewReader(txn.Category),
 		"payer":        strings.NewReader(txn.Payer),
 		"details":      strings.NewReader(txn.Details),
+		"split":        strings.NewReader(splitString),
 	}
 	var b bytes.Buffer
 	w := multipart.NewWriter(&b)

--- a/server/internal/integration_test/shared_txns_integ_test.go
+++ b/server/internal/integration_test/shared_txns_integ_test.go
@@ -365,16 +365,16 @@ func TestGetUnsettledTxnsFromTracker(t *testing.T) {
 
 			assert.Equal(tc.wantCode, response.Code)
 
-			var got []app.SharedTransaction
+			var got app.UnsettledResponse
 			err := json.NewDecoder(response.Body).Decode(&got)
 			if err != nil {
 				t.Fatalf("error parsing response from server %q into slice of shared txns: %v", response.Body, err)
 			}
-			assert.Len(got, len(tc.wantTransactions))
+			assert.Len(got.Txns, len(tc.wantTransactions))
 
 			// remove the ID from the got transactions to account for randomly generated
 			var gotWithoutID []app.SharedTransaction
-			for _, txn := range got {
+			for _, txn := range got.Txns {
 				gotWithoutID = append(gotWithoutID, RemoveSharedTxnID(txn))
 			}
 
@@ -560,13 +560,13 @@ func TestSettleTxns(t *testing.T) {
 			request.AddCookie(&tc.cookie)
 			response := httptest.NewRecorder()
 			router.ServeHTTP(response, request)
-			var unsettled []app.SharedTransaction
+			var unsettled app.UnsettledResponse
 			err := json.NewDecoder(response.Body).Decode(&unsettled)
 			if err != nil {
 				t.Fatalf("error parsing response from server %q into slice of shared txns: %v", response.Body, err)
 			}
 
-			request = app.NewSettleTxnsRequest(t, unsettled)
+			request = app.NewSettleTxnsRequest(t, unsettled.Txns)
 			request.AddCookie(&tc.cookie)
 			response = httptest.NewRecorder()
 			router.ServeHTTP(response, request)
@@ -579,12 +579,12 @@ func TestSettleTxns(t *testing.T) {
 			response = httptest.NewRecorder()
 			router.ServeHTTP(response, request)
 
-			var got []app.SharedTransaction
+			var got app.UnsettledResponse
 			err = json.NewDecoder(response.Body).Decode(&got)
 			if err != nil {
 				t.Fatalf("error parsing response from server %q into slice of shared txns: %v", response.Body, err)
 			}
-			assert.Len(got, len(tc.wantTxns))
+			assert.Len(got.Txns, len(tc.wantTxns))
 		})
 	}
 }

--- a/server/internal/integration_test/shared_txns_integ_test.go
+++ b/server/internal/integration_test/shared_txns_integ_test.go
@@ -360,6 +360,13 @@ func TestGetUnsettledTxnsFromTracker(t *testing.T) {
 			loggedInUser:     "user-01",
 			wantOwed:         400,
 		},
+		"for a tracker with at least one unsettled txn when the non-payer is logged in": {
+			tracker:          "test-tracker-01",
+			wantTransactions: []app.SharedTransaction{testUnsettledTxn},
+			wantCode:         http.StatusOK,
+			loggedInUser:     "user-02",
+			wantOwed:         -400,
+		},
 	}
 
 	for name, tc := range tests {
@@ -381,6 +388,7 @@ func TestGetUnsettledTxnsFromTracker(t *testing.T) {
 				t.Fatalf("error parsing response from server %q into slice of shared txns: %v", response.Body, err)
 			}
 			assert.Len(got.Txns, len(tc.wantTransactions))
+			assert.Equal(got.Debtee, tc.loggedInUser)
 
 			// remove the ID from the got transactions to account for randomly generated ID
 			var gotWithoutID []app.SharedTransaction

--- a/server/internal/integration_test/shared_txns_integ_test.go
+++ b/server/internal/integration_test/shared_txns_integ_test.go
@@ -397,6 +397,10 @@ func TestUpdateSharedTxns(t *testing.T) {
 		Tracker:      "test-tracker-01",
 		Category:     "test-category",
 		Payer:        "user-01",
+		Split: map[string]float64{
+			"user-01": 0.6,
+			"user-02": 0.4,
+		},
 	}
 	updatedTxn := app.SharedTransaction{
 		Participants: []string{"user-01", "user-02"},
@@ -406,6 +410,10 @@ func TestUpdateSharedTxns(t *testing.T) {
 		Tracker:      "test-tracker-01",
 		Category:     "different-category",
 		Payer:        "user-02",
+		Split: map[string]float64{
+			"user-01": 0.7,
+			"user-02": 0.3,
+		},
 	}
 
 	tests := map[string]struct {

--- a/server/internal/integration_test/shared_txns_integ_test.go
+++ b/server/internal/integration_test/shared_txns_integ_test.go
@@ -331,6 +331,10 @@ var testUnsettledTxn = app.SharedTransaction{
 	Unsettled:    true,
 	Category:     "test-category",
 	Payer:        "user-01",
+	Split: map[string]float64{
+		"user-01": 0.6,
+		"user-02": 0.4,
+	},
 }
 
 func TestGetUnsettledTxnsFromTracker(t *testing.T) {


### PR DESCRIPTION
Resolves #63 

- Adds custom Split to shared transactions for uneven transaction splits
- Add a TrackerLayout for tracker pages
  - Add a page to see the unsettled details for each tracker
- Add UnsettledResponse, CalculateDebts for unsettled transactions