### PR TITLE
Get *all* transactions for a user

### DIFF
--- a/client/pages/index.tsx
+++ b/client/pages/index.tsx
@@ -3,6 +3,12 @@ import useSWR from 'swr';
 import { Transaction } from 'types/Transaction';
 import { Temporal } from 'temporal-polyfill';
 import { epochSecToLocaleString, plainDateStringToEpochSec } from 'utils/dates';
+import { SharedTxn } from './shared/trackers/[trackerId]';
+
+type AllTxnsResponse = {
+  transactions: Transaction[];
+  sharedTransactions: SharedTxn[];
+};
 
 export default function Home() {
   const { user } = useUserContext();
@@ -12,18 +18,25 @@ export default function Home() {
   const threeMonthsAgoEpochSeconds = plainDateStringToEpochSec(
     Temporal.Now.plainDateISO().subtract({ months: 3 }).toString(),
   );
-  const { data: txns, error } = useSWR<Transaction[]>(() =>
+  const { data: res, error } = useSWR<AllTxnsResponse>(() =>
     user
-      ? `${process.env.NEXT_PUBLIC_API_BASE_URL}/transactions/user/${user.id}/range?from=${threeMonthsAgoEpochSeconds}&to=${todayEpochSeconds}`
+      ? `${process.env.NEXT_PUBLIC_API_BASE_URL}/transactions/user/${user.id}/all?from=${threeMonthsAgoEpochSeconds}&to=${todayEpochSeconds}`
       : null,
   );
+
+  let txns: (Transaction | SharedTxn)[] = [];
+  if (res) {
+    txns = [...res.transactions, ...res.sharedTransactions].sort(
+      (a, b) => b.date - a.date, // sorted descending, so the most recent dates are shown first
+    );
+  }
 
   return (
     <>
       <div>Hi, {user.username}!</div>
       {error && <div>Failed to load recent transactions</div>}
-      {txns === null && <div>Loading recent transactions....</div>}
-      {txns && txns.length === 0 && <div>No transactions to show</div>}
+      {res === null && <div>Loading recent transactions....</div>}
+      {res && txns.length === 0 && <div>No transactions to show</div>}
       {txns?.map((txn) => (
         <article
           className="mt-4 cursor-pointer border-2 p-2 hover:bg-slate-200 active:bg-slate-300"

--- a/client/pages/index.tsx
+++ b/client/pages/index.tsx
@@ -4,6 +4,7 @@ import { Transaction } from 'types/Transaction';
 import { Temporal } from 'temporal-polyfill';
 import { epochSecToLocaleString, plainDateStringToEpochSec } from 'utils/dates';
 import { SharedTxn } from './shared/trackers/[trackerId]';
+import { calculatePersonalTotal } from 'utils/analysis';
 
 type AllTxnsResponse = {
   transactions: Transaction[];
@@ -30,6 +31,7 @@ export default function Home() {
       (a, b) => b.date - a.date, // sorted descending, so the most recent dates are shown first
     );
   }
+  const total = calculatePersonalTotal(user.id, txns);
 
   return (
     <>
@@ -37,6 +39,11 @@ export default function Home() {
       {error && <div>Failed to load recent transactions</div>}
       {res === null && <div>Loading recent transactions....</div>}
       {res && txns.length === 0 && <div>No transactions to show</div>}
+      {txns && (
+        <p className="mt-4">
+          You have spent a total of {total} over {txns.length} transactions.
+        </p>
+      )}
       {txns?.map((txn) => (
         <article
           className="mt-4 cursor-pointer border-2 p-2 hover:bg-slate-200 active:bg-slate-300"

--- a/client/pages/shared/trackers/[trackerId]/unsettled-txns.tsx
+++ b/client/pages/shared/trackers/[trackerId]/unsettled-txns.tsx
@@ -21,11 +21,13 @@ export default function UnsettledTxnPage() {
     <TrackerLayout>
       {error && <div>Error loading unsettled transactions</div>}
       {response === null && <div>Loading unsettled transactions</div>}
-      {response && (
-        <div className="mt-4">
+      {response && response.transactions.length ? (
+        <p className="mt-4">You currently have no unsettled transactions!</p>
+      ) : (
+        <p className="mt-4">
           {response.debtor} owes {response.debtee} {response.amountOwed} for{' '}
           {response.transactions.length} transactions
-        </div>
+        </p>
       )}
     </TrackerLayout>
   );

--- a/client/utils/analysis.ts
+++ b/client/utils/analysis.ts
@@ -38,3 +38,23 @@ export function totalsBySubCategory(txns: Transaction[] | SharedTxn[]) {
     total,
   }));
 }
+
+export function calculatePersonalTotal(
+  user: string,
+  txns: (Transaction | SharedTxn)[],
+) {
+  let total = 0;
+  for (const txn of txns) {
+    if ('split' in txn) {
+      if (txn.split[user]) {
+        total += txn.amount * txn.split[user];
+        continue;
+      }
+      // if there's no split, use the default split
+      total += txn.amount * (1 / txn.participants.length);
+      continue;
+    }
+    total += txn.amount;
+  }
+  return total;
+}

--- a/server/internal/app/app.go
+++ b/server/internal/app/app.go
@@ -47,6 +47,7 @@ type Store interface {
 	DeleteSharedTxn(input DelSharedTxnInput) error
 	GetTxnsByTracker(trackerID string) ([]SharedTransaction, error)
 	GetTxnsByTrackerBetweenDates(trackerID string, from, to int64) ([]SharedTransaction, error)
+	GetAllTxnsByUser(userID string) ([]Transaction, []SharedTransaction, error)
 	GetUnsettledTxnsByTracker(trackerID string) ([]SharedTransaction, error)
 	SettleTxns(txns []SharedTransaction) error
 }

--- a/server/internal/app/app.go
+++ b/server/internal/app/app.go
@@ -47,7 +47,7 @@ type Store interface {
 	DeleteSharedTxn(input DelSharedTxnInput) error
 	GetTxnsByTracker(trackerID string) ([]SharedTransaction, error)
 	GetTxnsByTrackerBetweenDates(trackerID string, from, to int64) ([]SharedTransaction, error)
-	GetAllTxnsByUser(userID string) ([]Transaction, []SharedTransaction, error)
+	GetAllTxnsByUserBetweenDates(userID string, from, to int64) ([]Transaction, []SharedTransaction, error)
 	GetUnsettledTxnsByTracker(trackerID string) ([]SharedTransaction, error)
 	SettleTxns(txns []SharedTransaction) error
 }

--- a/server/internal/app/mocks/mock_app.go
+++ b/server/internal/app/mocks/mock_app.go
@@ -122,6 +122,22 @@ func (mr *MockStoreMockRecorder) DeleteTransaction(txnID, userID interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTransaction", reflect.TypeOf((*MockStore)(nil).DeleteTransaction), txnID, userID)
 }
 
+// GetAllTxnsByUser mocks base method.
+func (m *MockStore) GetAllTxnsByUser(userID string) ([]app.Transaction, []app.SharedTransaction, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAllTxnsByUser", userID)
+	ret0, _ := ret[0].([]app.Transaction)
+	ret1, _ := ret[1].([]app.SharedTransaction)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetAllTxnsByUser indicates an expected call of GetAllTxnsByUser.
+func (mr *MockStoreMockRecorder) GetAllTxnsByUser(userID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllTxnsByUser", reflect.TypeOf((*MockStore)(nil).GetAllTxnsByUser), userID)
+}
+
 // GetAllUsers mocks base method.
 func (m *MockStore) GetAllUsers() ([]app.User, error) {
 	m.ctrl.T.Helper()

--- a/server/internal/app/mocks/mock_app.go
+++ b/server/internal/app/mocks/mock_app.go
@@ -122,20 +122,20 @@ func (mr *MockStoreMockRecorder) DeleteTransaction(txnID, userID interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTransaction", reflect.TypeOf((*MockStore)(nil).DeleteTransaction), txnID, userID)
 }
 
-// GetAllTxnsByUser mocks base method.
-func (m *MockStore) GetAllTxnsByUser(userID string) ([]app.Transaction, []app.SharedTransaction, error) {
+// GetAllTxnsByUserBetweenDates mocks base method.
+func (m *MockStore) GetAllTxnsByUserBetweenDates(userID string, from, to int64) ([]app.Transaction, []app.SharedTransaction, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllTxnsByUser", userID)
+	ret := m.ctrl.Call(m, "GetAllTxnsByUserBetweenDates", userID, from, to)
 	ret0, _ := ret[0].([]app.Transaction)
 	ret1, _ := ret[1].([]app.SharedTransaction)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
 
-// GetAllTxnsByUser indicates an expected call of GetAllTxnsByUser.
-func (mr *MockStoreMockRecorder) GetAllTxnsByUser(userID interface{}) *gomock.Call {
+// GetAllTxnsByUserBetweenDates indicates an expected call of GetAllTxnsByUserBetweenDates.
+func (mr *MockStoreMockRecorder) GetAllTxnsByUserBetweenDates(userID, from, to interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllTxnsByUser", reflect.TypeOf((*MockStore)(nil).GetAllTxnsByUser), userID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllTxnsByUserBetweenDates", reflect.TypeOf((*MockStore)(nil).GetAllTxnsByUserBetweenDates), userID, from, to)
 }
 
 // GetAllUsers mocks base method.

--- a/server/internal/app/sharedtxns.go
+++ b/server/internal/app/sharedtxns.go
@@ -68,9 +68,14 @@ func (a *App) GetTxnsByTrackerBetweenDates(w http.ResponseWriter, r *http.Reques
 	}
 }
 
-// GetAllTxnsByUser handles a HTTP request to get all txns AND shared txns from
+type AllTxnResponse struct {
+	Txns       []Transaction       `json:"transactions"`
+	SharedTxns []SharedTransaction `json:"sharedTransactions"`
+}
+
+// GetAllTxnsByUserBetweenDates handles a HTTP request to get all txns AND shared txns from
 // a user
-func (a *App) GetAllTxnsByUser(w http.ResponseWriter, r *http.Request) {
+func (a *App) GetAllTxnsByUserBetweenDates(w http.ResponseWriter, r *http.Request) {
 	userID := r.Context().Value(CtxKeyUserID).(string)
 	from := r.Context().Value(CtxKeyDateFrom).(int64)
 	to := r.Context().Value(CtxKeyDateTo).(int64)
@@ -81,9 +86,9 @@ func (a *App) GetAllTxnsByUser(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 
-	response := map[string]interface{}{
-		"transactions":       txns,
-		"sharedTransactions": sharedTxns,
+	response := AllTxnResponse{
+		Txns:       txns,
+		SharedTxns: sharedTxns,
 	}
 	w.Header().Set("content-type", jsonContentType)
 	err = json.NewEncoder(w).Encode(response)

--- a/server/internal/app/sharedtxns.go
+++ b/server/internal/app/sharedtxns.go
@@ -68,6 +68,29 @@ func (a *App) GetTxnsByTrackerBetweenDates(w http.ResponseWriter, r *http.Reques
 	}
 }
 
+// GetAllTxnsByUser handles a HTTP request to get all txns AND shared txns from
+// a user
+func (a *App) GetAllTxnsByUser(w http.ResponseWriter, r *http.Request) {
+	userID := r.Context().Value(CtxKeyUserID).(string)
+
+	txns, sharedTxns, err := a.store.GetAllTxnsByUser(userID)
+	// TODO: if the user is not found, 404
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+
+	response := map[string]interface{}{
+		"transactions":       txns,
+		"sharedTransactions": sharedTxns,
+	}
+	w.Header().Set("content-type", jsonContentType)
+	err = json.NewEncoder(w).Encode(response)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
 func parseSharedTxnForm(r *http.Request, w http.ResponseWriter) *SharedTransaction {
 	err := r.ParseMultipartForm(1000)
 	if err != nil {

--- a/server/internal/app/sharedtxns.go
+++ b/server/internal/app/sharedtxns.go
@@ -72,8 +72,10 @@ func (a *App) GetTxnsByTrackerBetweenDates(w http.ResponseWriter, r *http.Reques
 // a user
 func (a *App) GetAllTxnsByUser(w http.ResponseWriter, r *http.Request) {
 	userID := r.Context().Value(CtxKeyUserID).(string)
+	from := r.Context().Value(CtxKeyDateFrom).(int64)
+	to := r.Context().Value(CtxKeyDateTo).(int64)
 
-	txns, sharedTxns, err := a.store.GetAllTxnsByUser(userID)
+	txns, sharedTxns, err := a.store.GetAllTxnsByUserBetweenDates(userID, from, to)
 	// TODO: if the user is not found, 404
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/server/internal/app/sharedtxns_test.go
+++ b/server/internal/app/sharedtxns_test.go
@@ -386,7 +386,7 @@ func TestGetAllTxnsByUser(t *testing.T) {
 			req = req.WithContext(ctx)
 			response := httptest.NewRecorder()
 
-			handler := http.HandlerFunc(a.GetAllTxnsByUser)
+			handler := http.HandlerFunc(a.GetAllTxnsByUserBetweenDates)
 			handler.ServeHTTP(response, req)
 
 			assert.Equal(tc.wantCode, response.Code)

--- a/server/internal/app/sharedtxns_test.go
+++ b/server/internal/app/sharedtxns_test.go
@@ -353,15 +353,22 @@ func TestCalculateDebts(t *testing.T) {
 }
 
 func TestGetAllTxnsByUser(t *testing.T) {
+	var testFrom int64 = 1000
+	var testTo int64 = 2000
+
 	tests := map[string]struct {
 		user           string
+		from           int64
+		to             int64
 		expectationsFn mock_app.MockAppFn
 		wantCode       int
 	}{
 		"it calls the store function with the user to retrieve the txns": {
 			user: "test-user",
+			from: testFrom,
+			to:   testTo,
 			expectationsFn: func(ma *mock_app.App) {
-				ma.MockStore.EXPECT().GetAllTxnsByUser("test-user").Times(1)
+				ma.MockStore.EXPECT().GetAllTxnsByUserBetweenDates("test-user", testFrom, testTo).Times(1)
 			},
 			wantCode: http.StatusOK,
 		},
@@ -372,8 +379,10 @@ func TestGetAllTxnsByUser(t *testing.T) {
 			assert := assert.New(t)
 			a := mock_app.SetUp(t, tc.expectationsFn)
 
-			req := app.NewGetAllTxnsByUserRequest(tc.user)
+			req := app.NewGetAllTxnsByUserBetweenDatesRequest(tc.user, tc.from, tc.to)
 			ctx := context.WithValue(req.Context(), app.CtxKeyUserID, tc.user)
+			ctx = context.WithValue(ctx, app.CtxKeyDateFrom, tc.from)
+			ctx = context.WithValue(ctx, app.CtxKeyDateTo, tc.to)
 			req = req.WithContext(ctx)
 			response := httptest.NewRecorder()
 

--- a/server/internal/app/sharedtxns_test.go
+++ b/server/internal/app/sharedtxns_test.go
@@ -352,6 +352,39 @@ func TestCalculateDebts(t *testing.T) {
 	}
 }
 
+func TestGetAllTxnsByUser(t *testing.T) {
+	tests := map[string]struct {
+		user           string
+		expectationsFn mock_app.MockAppFn
+		wantCode       int
+	}{
+		"it calls the store function with the user to retrieve the txns": {
+			user: "test-user",
+			expectationsFn: func(ma *mock_app.App) {
+				ma.MockStore.EXPECT().GetAllTxnsByUser("test-user").Times(1)
+			},
+			wantCode: http.StatusOK,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			a := mock_app.SetUp(t, tc.expectationsFn)
+
+			req := app.NewGetAllTxnsByUserRequest(tc.user)
+			ctx := context.WithValue(req.Context(), app.CtxKeyUserID, tc.user)
+			req = req.WithContext(ctx)
+			response := httptest.NewRecorder()
+
+			handler := http.HandlerFunc(a.GetAllTxnsByUser)
+			handler.ServeHTTP(response, req)
+
+			assert.Equal(tc.wantCode, response.Code)
+		})
+	}
+}
+
 func TestGetTxnsByTrackerBetweenDates(t *testing.T) {
 	var testFrom int64 = 1000
 	var testTo int64 = 2000

--- a/server/internal/app/testing.go
+++ b/server/internal/app/testing.go
@@ -205,6 +205,13 @@ func NewGetTxnsByTrackerBetweenDatesRequest(trackerID string, from, to int64) *h
 	return req
 }
 
+// NewGetAllTxnsByUserRequest creates a request to be used in tests to get a list
+// of all txns and shared txns of a user
+func NewGetAllTxnsByUserRequest(userID string) *http.Request {
+	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/transactions/users/%s/all", userID), nil)
+	return req
+}
+
 // MakeSharedTxnRequestPayload generates the payload to be given to NewCreateSharedTxnRequest
 func MakeSharedTxnRequestPayload(txn SharedTransaction) (bytes.Buffer, string) {
 	// make a comma separated list of participants

--- a/server/internal/app/testing.go
+++ b/server/internal/app/testing.go
@@ -207,8 +207,8 @@ func NewGetTxnsByTrackerBetweenDatesRequest(trackerID string, from, to int64) *h
 
 // NewGetAllTxnsByUserRequest creates a request to be used in tests to get a list
 // of all txns and shared txns of a user
-func NewGetAllTxnsByUserRequest(userID string) *http.Request {
-	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/transactions/users/%s/all", userID), nil)
+func NewGetAllTxnsByUserBetweenDatesRequest(userID string, from, to int64) *http.Request {
+	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/transactions/users/%s/all?from=%d&to=%d", userID, from, to), nil)
 	return req
 }
 

--- a/server/internal/app/testing.go
+++ b/server/internal/app/testing.go
@@ -208,7 +208,7 @@ func NewGetTxnsByTrackerBetweenDatesRequest(trackerID string, from, to int64) *h
 // NewGetAllTxnsByUserRequest creates a request to be used in tests to get a list
 // of all txns and shared txns of a user
 func NewGetAllTxnsByUserBetweenDatesRequest(userID string, from, to int64) *http.Request {
-	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/transactions/users/%s/all?from=%d&to=%d", userID, from, to), nil)
+	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/transactions/user/%s/all?from=%d&to=%d", userID, from, to), nil)
 	return req
 }
 

--- a/server/internal/ddb/ddb.go
+++ b/server/internal/ddb/ddb.go
@@ -307,12 +307,12 @@ func (d *dynamoDB) GetTxnsByTrackerBetweenDates(trackerID string, from, to int64
 }
 
 func (d *dynamoDB) GetAllTxnsByUserBetweenDates(userID string, from, to int64) ([]app.Transaction, []app.SharedTransaction, error) {
-	txnItems, err := d.transactions.GetBetweenDates(userID, from, to)
+	txnItems, err := d.transactions.GetBetweenDates(userID, from, to+1)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	sharedTxnItems, err := d.sharedTxn.GetByUserBetweenDates(userID, from, to)
+	sharedTxnItems, err := d.sharedTxn.GetByUserBetweenDates(userID, from, to+1)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/server/internal/ddb/ddb.go
+++ b/server/internal/ddb/ddb.go
@@ -317,7 +317,9 @@ func (d *dynamoDB) GetAllTxnsByUserBetweenDates(userID string, from, to int64) (
 		return nil, nil, err
 	}
 
-	var sharedTxns []app.SharedTransaction
+	// empty slices instead of nil slice so the JSON response will be an empty
+	// array instead of null
+	sharedTxns := []app.SharedTransaction{}
 	for _, i := range sharedTxnItems {
 		txn, err := sharedTxnItemToSharedTxn(i)
 		if err != nil {
@@ -326,7 +328,7 @@ func (d *dynamoDB) GetAllTxnsByUserBetweenDates(userID string, from, to int64) (
 		sharedTxns = append(sharedTxns, txn)
 	}
 
-	var txns []app.Transaction
+	txns := []app.Transaction{}
 	for _, i := range txnItems {
 		txns = append(txns, (txnItemToTxn(i)))
 	}

--- a/server/internal/integration_test/shared_txns_integ_test.go
+++ b/server/internal/integration_test/shared_txns_integ_test.go
@@ -525,6 +525,14 @@ func TestGetAllTxnsFromUsersBetweenDates(t *testing.T) {
 			wantSharedTxns: []app.SharedTransaction{initialTxn},
 			wantCode:       http.StatusOK,
 		},
+		"with a date range and user containing a transactions that has a date equal to 'to'": {
+			user:           "user-01",
+			from:           20000,
+			to:             33333,
+			wantTxns:       []app.Transaction{initialDetails},
+			wantSharedTxns: []app.SharedTransaction{initialTxn},
+			wantCode:       http.StatusOK,
+		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/server/internal/integration_test/shared_txns_integ_test.go
+++ b/server/internal/integration_test/shared_txns_integ_test.go
@@ -484,6 +484,92 @@ func TestGetTxnsFromTrackerBetweenDates(t *testing.T) {
 	}
 }
 
+func TestGetAllTxnsFromUsersBetweenDates(t *testing.T) {
+	initialDetails := app.Transaction{
+		Location: "test-location",
+		UserID:   "user-01",
+		Amount:   100,
+		Date:     33333,
+		Category: "test.category",
+		Details:  "test-details",
+	}
+
+	initialTxn := app.SharedTransaction{
+		Participants: []string{"user-01", "user-02"},
+		Location:     "test-shop",
+		Amount:       123456,
+		Date:         20000,
+		Tracker:      "test-tracker-01",
+		Unsettled:    true,
+		Category:     "test-category",
+		Payer:        "user-01",
+		Split: map[string]float64{
+			"user-01": 0.6,
+			"user-02": 0.4,
+		},
+	}
+
+	tests := map[string]struct {
+		user           string
+		from           int64
+		to             int64
+		wantTxns       []app.Transaction
+		wantSharedTxns []app.SharedTransaction
+		wantCode       int
+	}{
+		"with a date range and user containing a transactions that has a date equal to 'from'": {
+			user:           "user-01",
+			from:           20000,
+			to:             40000,
+			wantTxns:       []app.Transaction{initialDetails},
+			wantSharedTxns: []app.SharedTransaction{initialTxn},
+			wantCode:       http.StatusOK,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			router, tearDownDB := SetUpTestServer(t)
+			defer tearDownDB(t)
+			assert := assert.New(t)
+
+			CreateUser(t, TestSeanUser, router)
+			CreateTestTxn(t, router, initialDetails, tc.user)
+
+			// create the transaction
+			request := app.NewCreateSharedTxnRequest(initialTxn)
+			request.AddCookie(CreateCookie(tc.user))
+			response := httptest.NewRecorder()
+			router.ServeHTTP(response, request)
+
+			// get the transactions
+			request = app.NewGetAllTxnsByUserBetweenDatesRequest(tc.user, tc.from, tc.to)
+			request.AddCookie(CreateCookie(tc.user))
+			response = httptest.NewRecorder()
+			router.ServeHTTP(response, request)
+
+			assert.Equal(tc.wantCode, response.Code)
+
+			var got app.AllTxnResponse
+			err := json.NewDecoder(response.Body).Decode(&got)
+			assert.NoError(err)
+			assert.Len(got.SharedTxns, len(tc.wantSharedTxns))
+			assert.Len(got.Txns, len(tc.wantTxns))
+
+			if len(tc.wantSharedTxns) > 0 {
+				var gotWithoutID []app.SharedTransaction
+				for _, txn := range got.SharedTxns {
+					gotWithoutID = append(gotWithoutID, RemoveSharedTxnID(txn))
+				}
+				assert.ElementsMatch(gotWithoutID, tc.wantSharedTxns)
+			}
+
+			if len(tc.wantTxns) > 0 {
+				AssertEqualTxnDetails(t, got.Txns[0], tc.wantTxns[0])
+			}
+		})
+	}
+}
+
 func TestUpdateSharedTxns(t *testing.T) {
 	assert := assert.New(t)
 	initialTxn := app.SharedTransaction{

--- a/server/internal/router/router.go
+++ b/server/internal/router/router.go
@@ -40,6 +40,9 @@ func Init(a *app.App) *chi.Mux {
 				Get("/transactions/user/{userID}", a.GetTransactionsByUser)
 			r.With(userIDCtx).
 				With(dateRangeCtx).
+				Get("/transactions/user/{userID}/all", a.GetAllTxnsByUserBetweenDates)
+			r.With(userIDCtx).
+				With(dateRangeCtx).
 				Get("/transactions/user/{userID}/range", a.GetTxnsBetweenDates)
 			r.With(transactionIDCtx).
 				Get("/transactions/{transactionID}", a.GetTransaction)


### PR DESCRIPTION
## Overview

- Closes #60
- Add GetAllTxnsByUserBetweenDates to app and ddb
- Add GetByUserBetweenDates to sharedtxns repo
- Use the new route for the home page in the UI
- Need to use two queries to ddb because the type of the items are different and I'm using the Query method from nabeken.
  - I could unmarshal the results dependent on their entity type, but for how the app is set up currently, I think this is fine.