### PR TITLE
Make it harder to delete transactions

### DIFF
--- a/client/components/SharedTxnReadUpdateForm.tsx
+++ b/client/components/SharedTxnReadUpdateForm.tsx
@@ -29,6 +29,26 @@ async function updateSharedTxn(
   );
 }
 
+async function deleteSharedTxn(txn: SharedTxn) {
+  const payload = {
+    tracker: txn.tracker,
+    txnID: txn.id,
+    participants: txn.participants,
+  };
+
+  await fetch(
+    `${process.env.NEXT_PUBLIC_API_BASE_URL}/trackers/${txn.tracker}/transactions/${txn.id}`,
+    {
+      method: 'DELETE',
+      headers: {
+        Accept: 'application/json',
+      },
+      credentials: 'include',
+      body: JSON.stringify(payload),
+    },
+  );
+}
+
 interface Props {
   txn: SharedTxn;
   tracker: Tracker;
@@ -70,6 +90,14 @@ export default function SharedTxnReadUpdateForm({
     onApply();
   };
 
+  function handleDelete(e: React.MouseEvent) {
+    e.stopPropagation();
+    mutate(
+      `${process.env.NEXT_PUBLIC_API_BASE_URL}/trackers/${tracker.id}/transactions`,
+      deleteSharedTxn(txn),
+    );
+  }
+
   return (
     <SharedTxnFormBase
       title="Update Shared Transaction"
@@ -77,12 +105,20 @@ export default function SharedTxnReadUpdateForm({
       register={register}
       onSubmit={handleSubmit(submitCallback)}
     >
-      <div className="mt-4 flex justify-end">
+      <div className="mt-4 flex">
+        <div className="flex-grow">
+          <button
+            className="rounded bg-red-500 py-2 px-4 text-sm font-bold uppercase text-white hover:bg-red-700 focus:outline-none focus:ring active:bg-red-300"
+            onClick={handleDelete}
+          >
+            Delete transaction
+          </button>
+        </div>
         {formState.isDirty ? (
           <>
             <button
               className="rounded py-2 px-4 text-sm font-bold uppercase hover:bg-slate-200 focus:outline-none focus:ring"
-              onClick={() => onCancel()}
+              onClick={onCancel}
             >
               Cancel
             </button>
@@ -96,7 +132,7 @@ export default function SharedTxnReadUpdateForm({
         ) : (
           <button
             className="rounded py-2 px-4 text-sm font-bold uppercase hover:bg-slate-200 focus:outline-none focus:ring"
-            onClick={() => onCancel()}
+            onClick={onCancel}
           >
             Close
           </button>

--- a/client/components/TxnReadUpdateForm.tsx
+++ b/client/components/TxnReadUpdateForm.tsx
@@ -18,6 +18,16 @@ async function updateTransaction(data: TxnFormInputs, txnID: string) {
   });
 }
 
+async function deleteTransaction(txnId: string) {
+  await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/transactions/${txnId}`, {
+    method: 'DELETE',
+    headers: {
+      Accept: 'application/json',
+    },
+    credentials: 'include',
+  });
+}
+
 interface Props {
   txn: Transaction;
   onApply: () => void;
@@ -46,18 +56,34 @@ export default function TxnReadUpdateForm({ txn, onApply, onCancel }: Props) {
     onApply();
   };
 
+  function handleDelete(e: React.MouseEvent) {
+    e.stopPropagation();
+    mutate(
+      `${process.env.NEXT_PUBLIC_API_BASE_URL}/transactions/user/${user.id}`,
+      deleteTransaction(txn.id),
+    );
+  }
+
   return (
     <TxnFormBase
       title="Update Transaction"
       register={register}
       onSubmit={handleSubmit(submitCallback)}
     >
-      <div className="mt-4 flex justify-end">
+      <div className="mt-4 flex">
+        <div className="flex-grow">
+          <button
+            className="rounded bg-red-500 py-2 px-4 text-sm font-bold uppercase text-white hover:bg-red-700 focus:outline-none focus:ring active:bg-red-300"
+            onClick={handleDelete}
+          >
+            Delete transaction
+          </button>
+        </div>
         {formState.isDirty ? (
           <>
             <button
               className="rounded py-2 px-4 text-sm font-bold uppercase hover:bg-slate-200 focus:outline-none focus:ring"
-              onClick={() => onCancel()}
+              onClick={onCancel}
             >
               Cancel
             </button>
@@ -71,7 +97,7 @@ export default function TxnReadUpdateForm({ txn, onApply, onCancel }: Props) {
         ) : (
           <button
             className="rounded py-2 px-4 text-sm font-bold uppercase hover:bg-slate-200 focus:outline-none focus:ring"
-            onClick={() => onCancel()}
+            onClick={onCancel}
           >
             Close
           </button>

--- a/client/pages/personal/index.tsx
+++ b/client/pages/personal/index.tsx
@@ -8,16 +8,6 @@ import { Transaction } from 'types/Transaction';
 import PersonalLayout from 'components/LayoutPersonal';
 import { categoryNameFromKeyEN } from 'data/categories';
 
-async function deleteTransaction(txnId: string) {
-  await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/transactions/${txnId}`, {
-    method: 'DELETE',
-    headers: {
-      Accept: 'application/json',
-    },
-    credentials: 'include',
-  });
-}
-
 type TxnOneProps = {
   txn: Transaction;
   onTxnClick: (txn: Transaction) => void;
@@ -25,14 +15,6 @@ type TxnOneProps = {
 
 function TxnOne({ txn, onTxnClick }: TxnOneProps) {
   const { user } = useUserContext();
-
-  function handleDelete(e: React.MouseEvent) {
-    e.stopPropagation();
-    mutate(
-      `${process.env.NEXT_PUBLIC_API_BASE_URL}/transactions/user/${user.id}`,
-      deleteTransaction(txn.id),
-    );
-  }
 
   return (
     <article
@@ -42,12 +24,6 @@ function TxnOne({ txn, onTxnClick }: TxnOneProps) {
     >
       <div className="flex justify-between">
         <h3 className="text-lg">{txn.location}</h3>
-        <button
-          className="rounded bg-red-500 py-2 px-4 text-sm font-bold uppercase text-white hover:bg-red-700 focus:outline-none focus:ring active:bg-blue-300"
-          onClick={handleDelete}
-        >
-          Delete
-        </button>
       </div>
       <p>{txn.amount}</p>
       <p>{categoryNameFromKeyEN(txn.category)}</p>

--- a/client/pages/shared/trackers/[trackerId]/index.tsx
+++ b/client/pages/shared/trackers/[trackerId]/index.tsx
@@ -70,12 +70,6 @@ function SharedTxnOne({ txn, tracker, onTxnClick }: SharedTxnOneProps) {
     >
       <div className="flex justify-between">
         <h3 className="text-lg">{txn.location}</h3>
-        <button
-          className="rounded bg-red-500 py-2 px-4 text-sm font-bold uppercase text-white hover:bg-red-700 focus:outline-none focus:ring active:bg-blue-300"
-          onClick={handleDelete}
-        >
-          Delete
-        </button>
       </div>
       <p>
         {txn.amount} paid by {txn.payer}


### PR DESCRIPTION
## Overview

Resolves #101 

Currently, there is no confirmation modal after pressing delete. To prevent accidental deletes, we have moved it to the update form for now.

Delete shouldn't be an action you have to take that often anyway, so it doesn't need to be in a place that is easy to press.