### PR TITLE
Show transactions in descending date order

### DIFF
--- a/client/pages/personal/index.tsx
+++ b/client/pages/personal/index.tsx
@@ -2,7 +2,7 @@ import TxnCreateForm from 'components/TxnCreateForm';
 import TxnReadUpdateForm from 'components/TxnReadUpdateForm';
 import { useUserContext } from 'context/user';
 import { useState } from 'react';
-import useSWR, { mutate } from 'swr';
+import useSWR from 'swr';
 import { epochSecToLocaleString } from 'utils/dates';
 import { Transaction } from 'types/Transaction';
 import PersonalLayout from 'components/LayoutPersonal';
@@ -14,8 +14,6 @@ type TxnOneProps = {
 };
 
 function TxnOne({ txn, onTxnClick }: TxnOneProps) {
-  const { user } = useUserContext();
-
   return (
     <article
       className="mt-4 cursor-pointer border-2 p-2 hover:bg-slate-200 active:bg-slate-300"

--- a/client/pages/shared/trackers/[trackerId]/index.tsx
+++ b/client/pages/shared/trackers/[trackerId]/index.tsx
@@ -24,26 +24,6 @@ export interface SharedTxn {
   };
 }
 
-async function deleteSharedTxn(txn: SharedTxn) {
-  const payload = {
-    tracker: txn.tracker,
-    txnID: txn.id,
-    participants: txn.participants,
-  };
-
-  await fetch(
-    `${process.env.NEXT_PUBLIC_API_BASE_URL}/trackers/${txn.tracker}/transactions/${txn.id}`,
-    {
-      method: 'DELETE',
-      headers: {
-        Accept: 'application/json',
-      },
-      credentials: 'include',
-      body: JSON.stringify(payload),
-    },
-  );
-}
-
 /**
  * SharedTxnOne displays one shared transaction to be showed in a list.
  */
@@ -53,15 +33,7 @@ type SharedTxnOneProps = {
   onTxnClick: (txn: SharedTxn) => void;
 };
 
-function SharedTxnOne({ txn, tracker, onTxnClick }: SharedTxnOneProps) {
-  function handleDelete(e: React.MouseEvent) {
-    e.stopPropagation();
-    mutate(
-      `${process.env.NEXT_PUBLIC_API_BASE_URL}/trackers/${tracker.id}/transactions`,
-      deleteSharedTxn(txn),
-    );
-  }
-
+function SharedTxnOne({ txn, onTxnClick }: SharedTxnOneProps) {
   return (
     <article
       className="mt-4 cursor-pointer border-2 p-2 hover:bg-slate-200 active:bg-slate-300"

--- a/client/pages/shared/trackers/[trackerId]/index.tsx
+++ b/client/pages/shared/trackers/[trackerId]/index.tsx
@@ -29,7 +29,6 @@ export interface SharedTxn {
  */
 type SharedTxnOneProps = {
   txn: SharedTxn;
-  tracker: Tracker;
   onTxnClick: (txn: SharedTxn) => void;
 };
 
@@ -48,7 +47,6 @@ function SharedTxnOne({ txn, onTxnClick }: SharedTxnOneProps) {
       </p>
       <p>{categoryNameFromKeyEN(txn.category)}</p>
       <p>{epochSecToLocaleString(txn.date)}</p>
-      <p>{txn.tracker}</p>
       {txn.details && <p>{txn.details}</p>}
     </article>
   );
@@ -97,7 +95,6 @@ export default function TrackerPage() {
                     txn={txn}
                     onTxnClick={setSelectedTxn}
                     key={txn.id}
-                    tracker={tracker}
                   />
                 ))}
             </div>

--- a/server/internal/ddb/sharedtxns.go
+++ b/server/internal/ddb/sharedtxns.go
@@ -115,11 +115,14 @@ func (r *sharedTxnsRepo) GetFromTracker(trackerID string) ([]SharedTxnItem, erro
 	trackerIDKey := makeTrackerIDKey(trackerID)
 
 	options := []option.QueryInput{
-		option.QueryExpressionAttributeName(tablePrimaryKey, "#PK"),
-		option.QueryExpressionAttributeName(tableSortKey, "#SK"),
-		option.QueryExpressionAttributeValue(":trackerID", attributes.String(trackerIDKey)),
+		option.Index(gsi1Name),
+		option.QueryExpressionAttributeName(gsi1PrimaryKey, "#GSI1PK"),
+		option.QueryExpressionAttributeName(gsi1SortKey, "#GSI1SK"),
+		option.QueryExpressionAttributeValue(":trackerIDKey", attributes.String(trackerIDKey)),
 		option.QueryExpressionAttributeValue(":sharedTxnKeyPrefix", attributes.String(sharedTxnKeyPrefix)),
-		option.QueryKeyConditionExpression("#PK = :trackerID and begins_with(#SK, :sharedTxnKeyPrefix)"),
+		// sort descending
+		option.Reverse(),
+		option.QueryKeyConditionExpression("#GSI1PK = :trackerIDKey and begins_with(#GSI1SK, :sharedTxnKeyPrefix)"),
 	}
 
 	var items []SharedTxnItem

--- a/server/internal/ddb/transactions.go
+++ b/server/internal/ddb/transactions.go
@@ -101,11 +101,14 @@ func (t *txnRepo) GetByUserID(id string) ([]TxnItem, error) {
 	allTxnPrefix := fmt.Sprintf("%s#", txnKeyPrefix)
 
 	options := []option.QueryInput{
-		option.QueryExpressionAttributeName(tablePrimaryKey, "#PK"),
-		option.QueryExpressionAttributeName(tableSortKey, "#SK"),
+		option.Index(gsi1Name),
+		option.QueryExpressionAttributeName(gsi1PrimaryKey, "#GSI1PK"),
+		option.QueryExpressionAttributeName(gsi1SortKey, "#GSI1SK"),
 		option.QueryExpressionAttributeValue(":userKey", attributes.String(userIDKey)),
 		option.QueryExpressionAttributeValue(":allTxnPrefix", attributes.String(allTxnPrefix)),
-		option.QueryKeyConditionExpression("#PK = :userKey and begins_with(#SK, :allTxnPrefix)"),
+		option.QueryKeyConditionExpression("#GSI1PK = :userKey and begins_with(#GSI1SK, :allTxnPrefix)"),
+		// for descending date order
+		option.Reverse(),
 	}
 
 	var items []TxnItem

--- a/server/internal/ddb/transactions_test.go
+++ b/server/internal/ddb/transactions_test.go
@@ -28,8 +28,8 @@ func TestTransactionTable(t *testing.T) {
 		ID:         "test-txn-id",
 		UserID:     "test-user-id",
 		EntityType: "transaction",
-		GSI1PK:     "transactions",
-		GSI1SK:     "txn#test-txn-id",
+		GSI1PK:     "user#test-user-id",
+		GSI1SK:     "txn#1337#test-txn-id",
 	}
 
 	// no error raised the first time

--- a/server/internal/integration_test/helpers.go
+++ b/server/internal/integration_test/helpers.go
@@ -146,10 +146,10 @@ func RemoveSharedTxnID(txn app.SharedTransaction) app.SharedTransaction {
 	return txn
 }
 
-func CreateTestTxn(t *testing.T, r http.Handler, td app.Transaction, userid string) {
+func CreateTestTxn(t *testing.T, r http.Handler, td app.Transaction) {
 	payload := app.MakeTxnRequestPayload(td)
 	request := app.NewCreateTransactionRequest(payload)
-	request.AddCookie(CreateCookie(userid))
+	request.AddCookie(CreateCookie(td.UserID))
 	response := httptest.NewRecorder()
 	r.ServeHTTP(response, request)
 }

--- a/server/internal/integration_test/shared_txns_integ_test.go
+++ b/server/internal/integration_test/shared_txns_integ_test.go
@@ -572,7 +572,7 @@ func TestGetAllTxnsFromUsersBetweenDates(t *testing.T) {
 			assert := assert.New(t)
 
 			CreateUser(t, TestSeanUser, router)
-			CreateTestTxn(t, router, initialDetails, tc.user)
+			CreateTestTxn(t, router, initialDetails)
 
 			// create the transaction
 			request := app.NewCreateSharedTxnRequest(initialTxn)

--- a/server/internal/integration_test/shared_txns_integ_test.go
+++ b/server/internal/integration_test/shared_txns_integ_test.go
@@ -388,7 +388,6 @@ func TestGetUnsettledTxnsFromTracker(t *testing.T) {
 				t.Fatalf("error parsing response from server %q into slice of shared txns: %v", response.Body, err)
 			}
 			assert.Len(got.Txns, len(tc.wantTransactions))
-			assert.Equal(got.Debtee, tc.loggedInUser)
 
 			// remove the ID from the got transactions to account for randomly generated ID
 			var gotWithoutID []app.SharedTransaction
@@ -398,6 +397,7 @@ func TestGetUnsettledTxnsFromTracker(t *testing.T) {
 			assert.ElementsMatch(gotWithoutID, tc.wantTransactions)
 
 			if len(tc.wantTransactions) > 0 {
+				assert.Equal(got.Debtee, tc.loggedInUser)
 				assert.Equal(got.AmountOwed, tc.wantOwed)
 			}
 		})

--- a/server/internal/integration_test/txns_integ_test.go
+++ b/server/internal/integration_test/txns_integ_test.go
@@ -21,7 +21,7 @@ func TestCreatingTransactionsAndRetrievingThem(t *testing.T) {
 
 		// create a transaction and store it
 		wantTxnDetails := TestSeanTxnDetails
-		CreateTestTxn(t, router, wantTxnDetails, wantTxnDetails.UserID)
+		CreateTestTxn(t, router, wantTxnDetails)
 
 		// try and get it
 		request := app.NewGetTransactionsByUserRequest(wantTxnDetails.UserID)
@@ -48,7 +48,7 @@ func TestCreatingTransactionsAndRetrievingThem(t *testing.T) {
 		CreateUser(t, TestSeanUser, router)
 
 		wantTxnDetails := TestSeanTxnDetails
-		CreateTestTxn(t, router, wantTxnDetails, wantTxnDetails.UserID)
+		CreateTestTxn(t, router, wantTxnDetails)
 
 		request := app.NewGetTransactionsByUserRequest(wantTxnDetails.UserID)
 		request.AddCookie(CreateCookie(TestSeanUser.ID))
@@ -124,7 +124,7 @@ func TestCreatingTxns(t *testing.T) {
 			assert := assert.New(t)
 
 			CreateUser(t, TestSeanUser, router)
-			CreateTestTxn(t, router, tc.txnDetails, TestSeanUser.ID)
+			CreateTestTxn(t, router, tc.txnDetails)
 			request := app.NewGetTransactionsByUserRequest(TestSeanUser.ID)
 			request.AddCookie(CreateCookie(TestSeanUser.ID))
 			response := httptest.NewRecorder()
@@ -202,7 +202,7 @@ func TestGetTxnsByUser(t *testing.T) {
 
 			CreateUser(t, app.User{ID: tc.user}, router)
 			for _, txn := range tc.initTxns {
-				CreateTestTxn(t, router, txn, txn.UserID)
+				CreateTestTxn(t, router, txn)
 			}
 
 			request := app.NewGetTransactionsByUserRequest(tc.user)
@@ -262,7 +262,7 @@ func TestGetTxnBetweenDates(t *testing.T) {
 			assert := assert.New(t)
 
 			CreateUser(t, TestSeanUser, router)
-			CreateTestTxn(t, router, initialTxn, initialTxn.UserID)
+			CreateTestTxn(t, router, initialTxn)
 
 			request := app.NewGetTxnsBetweenDatesRequest(initialTxn.UserID, tc.from, tc.to)
 			request.AddCookie(CreateCookie(initialTxn.UserID))
@@ -330,7 +330,7 @@ func TestUpdateTransactions(t *testing.T) {
 			assert := assert.New(t)
 
 			CreateUser(t, test.user, router)
-			CreateTestTxn(t, router, test.initialTxnDetails, test.user.ID)
+			CreateTestTxn(t, router, test.initialTxnDetails)
 
 			// get transactions to get the transaction that was just added
 			request := app.NewGetTransactionsByUserRequest(test.user.ID)
@@ -373,7 +373,7 @@ func TestUpdateThenGetByDateRange(t *testing.T) {
 	assert := assert.New(t)
 
 	CreateUser(t, TestSeanUser, router)
-	CreateTestTxn(t, router, initialDetails, TestSeanUser.ID)
+	CreateTestTxn(t, router, initialDetails)
 
 	request := app.NewGetTxnsBetweenDatesRequest(TestSeanUser.ID, 30000, 40000)
 	request.AddCookie(CreateCookie(TestSeanUser.ID))
@@ -428,7 +428,7 @@ func TestDeletingTransactions(t *testing.T) {
 			assert := assert.New(t)
 
 			CreateUser(t, TestSeanUser, router)
-			CreateTestTxn(t, router, tc.td, tc.user)
+			CreateTestTxn(t, router, tc.td)
 
 			request := app.NewGetTransactionsByUserRequest(tc.user)
 			request.AddCookie(CreateCookie(tc.user))

--- a/server/internal/integration_test/txns_integ_test.go
+++ b/server/internal/integration_test/txns_integ_test.go
@@ -151,6 +151,22 @@ func TestGetTxnsByUser(t *testing.T) {
 		Category: "something",
 	}
 
+	initTxn2 := app.Transaction{
+		Location: "test-location",
+		UserID:   "a-user",
+		Amount:   300,
+		Date:     20000,
+		Category: "something",
+	}
+
+	initTxn3 := app.Transaction{
+		Location: "test-location",
+		UserID:   "a-user",
+		Amount:   300,
+		Date:     30000,
+		Category: "something",
+	}
+
 	tests := map[string]struct {
 		initTxns []app.Transaction
 		wantTxns []app.Transaction
@@ -166,6 +182,13 @@ func TestGetTxnsByUser(t *testing.T) {
 		"with a user that has one transaction": {
 			initTxns: []app.Transaction{initTxn1},
 			wantTxns: []app.Transaction{initTxn1},
+			user:     "a-user",
+			wantCode: http.StatusOK,
+		},
+		"with a user that has more than one transaction": {
+			initTxns: []app.Transaction{initTxn1, initTxn2, initTxn3},
+			// should be sorted in descending date
+			wantTxns: []app.Transaction{initTxn3, initTxn2, initTxn1},
 			user:     "a-user",
 			wantCode: http.StatusOK,
 		},


### PR DESCRIPTION
## Overview

Resolves #94.

- Shows transactions in descending date order on tracker pages and personal transactions pages.
- Remove the tracker ID from the transaction cards shown on the tracker page.