### PR TITLE
Handle split correctly

### DIFF
--- a/client/components/SharedTxnFormBase.tsx
+++ b/client/components/SharedTxnFormBase.tsx
@@ -46,7 +46,7 @@ export function makeSharedTxnPayload(
     amount: Number(data.amount),
     participants,
     split,
-    ...(data.settled && { settled: data.settled }),
+    ...(data.settled && { settled: true }),
   };
 
   return payload;

--- a/client/ddb/itemToModel.ts
+++ b/client/ddb/itemToModel.ts
@@ -36,5 +36,6 @@ export function sharedTxnItemToModel(item: SharedTxnItem): SharedTxn {
     participants: item.Participants,
     payer: item.Payer,
     ...(item.Unsettled && { unsettled: true }),
+    ...(item.SplitJSON && { split: JSON.parse(item.SplitJSON) }),
   };
 }

--- a/client/ddb/sharedTxns.test.ts
+++ b/client/ddb/sharedTxns.test.ts
@@ -341,6 +341,16 @@ describe('Shared Transactions', () => {
     txns = await getTxnsByTrackerBetweenDates(input);
     expect(txns).toHaveLength(0);
 
+    // second tracker, to is same as txn's create date for testing inclusive
+    // on to
+    input = {
+      tracker: second.tracker,
+      from: 1000 * 1000,
+      to: 2000 * 1000,
+    };
+    txns = await getTxnsByTrackerBetweenDates(input);
+    expect(txns).toHaveLength(1);
+
     // different tracker, no results in date range
     input = {
       tracker: 'no-results-tracker',

--- a/client/ddb/sharedTxns.ts
+++ b/client/ddb/sharedTxns.ts
@@ -287,7 +287,7 @@ export function makeSharedTxnRepository({ ddb, tableName }: DDBWithConfig) {
   }: ByTrackerBetweenDatesInput) {
     const trackerIdKey = makeTrackerIdKey(tracker);
     const txnDateFromKey = makeSharedTxnDateKey(from);
-    const txnDateToKey = makeSharedTxnDateKey(to);
+    const txnDateToKey = makeSharedTxnDateKey(to + 1); // to be inclusive for the date
 
     const results = await ddb.send(
       new QueryCommand({

--- a/client/ddb/txns.test.ts
+++ b/client/ddb/txns.test.ts
@@ -143,7 +143,7 @@ describe('Transactions', () => {
       userId: 'test-user',
       location: 'test-location',
       amount: 12345,
-      date: 1000 * 1000,
+      date: 2000 * 1000,
       category: 'unspecified.unspecified',
       details: '',
     } as const;
@@ -151,8 +151,17 @@ describe('Transactions', () => {
 
     let txns = await getBetweenDates({
       userId: testTxn.userId,
-      from: 1000 * 1000,
-      to: 1000 * 1500,
+      from: 2000 * 1000,
+      to: 2500 * 1000,
+    });
+    expect(txns).toHaveLength(1);
+    assertEqualDetails(txns[0], testTxn);
+
+    // is inclusive of the top end of the date range
+    txns = await getBetweenDates({
+      userId: testTxn.userId,
+      from: 1500 * 1000,
+      to: 2000 * 1000,
     });
     expect(txns).toHaveLength(1);
     assertEqualDetails(txns[0], testTxn);
@@ -160,8 +169,8 @@ describe('Transactions', () => {
     // a date range outside returns none
     txns = await getBetweenDates({
       userId: testTxn.userId,
-      from: 2000 * 1000,
-      to: 2000 * 1500,
+      from: 3000 * 1000,
+      to: 3000 * 1500,
     });
     expect(txns).toHaveLength(0);
   });

--- a/client/ddb/txns.ts
+++ b/client/ddb/txns.ts
@@ -183,7 +183,7 @@ export function makeTxnRepository({ ddb, tableName }: DDBWithConfig) {
   }) {
     const userIdKey = makeUserIdKey(userId);
     const txnDateFromKey = makeTxnDateKey(from);
-    const txnDateToKey = makeTxnDateKey(to);
+    const txnDateToKey = makeTxnDateKey(to + 1); // to include top part of range
 
     const result = await ddb.send(
       new QueryCommand({

--- a/client/pages/api/v1/trackers/[trackerId]/transactions/range.test.ts
+++ b/client/pages/api/v1/trackers/[trackerId]/transactions/range.test.ts
@@ -42,7 +42,7 @@ describe('getTxnsByTrackerBetweenDatesHandler', () => {
     req.query = {
       from: '12345678',
       to: '23456789',
-      tracker: 'test-tracker',
+      trackerId: 'test-tracker',
     };
     sessionMock.mockResolvedValueOnce(null);
     await getTxnsByTrackerBetweenDatesHandler(req, res);
@@ -55,7 +55,7 @@ describe('getTxnsByTrackerBetweenDatesHandler', () => {
     req.query = {
       from: '12345678',
       to: '23456789',
-      tracker: 'test-tracker',
+      trackerId: 'test-tracker',
     };
     sessionMock.mockResolvedValueOnce({
       user: {

--- a/client/pages/api/v1/trackers/[trackerId]/transactions/range.ts
+++ b/client/pages/api/v1/trackers/[trackerId]/transactions/range.ts
@@ -9,7 +9,7 @@ import { z, ZodError } from 'zod';
 const queryStringSchema = z.object({
   from: z.coerce.number(),
   to: z.coerce.number(),
-  tracker: z.string(),
+  trackerId: z.string(),
 });
 
 export default async function getTxnsByTrackerBetweenDatesHandler(
@@ -33,7 +33,7 @@ export default async function getTxnsByTrackerBetweenDatesHandler(
   const sharedTxnRepo = setUpSharedTxnRepo();
   var [items, err] = await withAsyncTryCatch(
     sharedTxnRepo.getTxnsByTrackerBetweenDates({
-      tracker: parsed!.tracker,
+      tracker: parsed!.trackerId,
       from: parsed!.from,
       to: parsed!.to,
     }),


### PR DESCRIPTION
## Overview

- Resolves #129 
- Makes range endpoints return txns inclusive of the top part of the range
- Makes endpoitns return the Split for shared transactions correctly